### PR TITLE
startProcess default environs fixes+enhancement, improved abortOnError, added pythonDocTest and compareVersions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -44,6 +44,25 @@ Changes affecting compatibility
   assert* methods would be silently ignored (potentially masking mistakes); 
   now it is an error to specify an invalid argument. 
 
+- The environment `startProcess` uses by default if no `environs=` 
+  parameter was specified has changed. Although the documentation states that 
+  a clean environment is used if no `environs` dictionary is specified, in 
+  PySys v1.1, 1.2 and 1.3 the Windows behaviour changed to include a copy of 
+  all environment variables in the parent PySys process (typically a very 
+  large set of variables), which could cause tests to unintentionally 
+  be affected by the environment it was run from. This is now fixed, so that 
+  a small minimal set of environment variables are always returned, as returned 
+  by the new `ProcessUser.getDefaultEnvirons()` method. As a result on Windows 
+  a much smaller set of environment variables and PATH/LD_LIBRARY_PATH 
+  components will be used, and on Unix instead of a completely empty 
+  environment, a few variables will now be set. If this causes problems you can 
+  temporarily go back to the legacy behaviour by setting this 
+  `pysysproject.xml` option::
+  
+     <property name="defaultEnvironsLegacyMode" value="true"/>
+
+  See https://github.com/pysys-test/pysys-test/issues/9 for more information. 
+
 New features
 ------------
 
@@ -161,6 +180,22 @@ New features
 - Added `ProcessUser.compareVersions()` static helper method for 
   comparing two alphanumeric dotted version strings. 
 
+- Added `ProcessUser.getDefaultEnvirons()` method which is now used by 
+  `startProcess()` to provide a minimal but clean set of environment variables 
+  for launching a given process, and can also be used as a basis for creating 
+  customized environments using the new `createEnvirons()` helper method. 
+  There are some new project properties to control how this works, which 
+  are added to the sample `pysysproject.xml` and recommended for new projects, 
+  but are not enabled by default in existing projects to maintain 
+  compatibility::
+  
+	<property name="defaultEnvironsDefaultLang" value="en_US.UTF-8"/>
+	<property name="defaultEnvironsTempDir" value="self.output'"/>  
+
+  See `ProcessUser.getDefaultEnvirons()` for more information on these. 
+  If needed you can further customize the environment by overriding 
+  `getDefaultEnvirons`. 
+
 - As an alternative to the usual `pysys.py` executable script, it is now also 
   possible to launch PySys using::
   
@@ -170,6 +205,12 @@ New features
 Bug fixes
 ---------
 
+- Fixed `startProcess()` to use a clean and minimal set of environment 
+  variables on Windows if no `environs=` parameter was specified, rather than 
+  copying all environment variables from the parent PySys process to the child 
+  process. See https://github.com/pysys-test/pysys-test/issues/9 for more 
+  information. 
+  
 - Fixed `startProcess()` to add a `BLOCKED` test outcome when a process fails 
   to start due to a `ProcessError`, unless `ignoreExitStatus=True`. Previously 
   this flag only affected non-zero exit codes, resulting in `ProcessError` 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -40,6 +40,9 @@ Changes affecting compatibility
   signature is now deprecated. As this API was added in 1.3.0 no other versions 
   are affected. 
 
+- In the previous release unknown or invalid keyword arguments passed to 
+  assert* methods would be silently ignored (potentially masking mistakes); 
+  now it is an error to specify an invalid argument. 
 
 New features
 ------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -155,6 +155,12 @@ New features
   a clearer way to indicate that PySys will automatically determine how many 
   threads to run tests with based on the number of available CPUs. 
 
+- Added `BaseTest.pythonDocTest()` method for executing the doctests in a 
+  Python file. 
+
+- Added `ProcessUser.compareVersions()` static helper method for 
+  comparing two alphanumeric dotted version strings. 
+
 - As an alternative to the usual `pysys.py` executable script, it is now also 
   possible to launch PySys using::
   

--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,7 @@ Project Links
 - Stackoverflow tag for questions: https://stackoverflow.com/tags/pysys
 - Change log: https://github.com/pysys-test/pysys-test/blob/master/CHANGELOG.rst
 - Bug/enhancement issue tracker: https://github.com/pysys-test/pysys-test/issues
-- Source respository: https://github.com/pysys-test/pysys-test
+- Source repository: https://github.com/pysys-test/pysys-test
 
 License and credits
 ===================

--- a/pysys-examples/internal/testcases/PySys_internal_022/run.py
+++ b/pysys-examples/internal/testcases/PySys_internal_022/run.py
@@ -9,7 +9,6 @@ class PySysTest(BaseTest):
 	
 		self.hprocess = self.startProcess(command=sys.executable,
 						  arguments = [script, "20", "3"],
-						  environs = os.environ,
 						  workingDir = self.output,
 						  stdout = "%s/counter.out" % self.output,
 						  stderr = "%s/counter.err" % self.output,

--- a/pysys-examples/internal/testcases/PySys_internal_024/Input/environment.py
+++ b/pysys-examples/internal/testcases/PySys_internal_024/Input/environment.py
@@ -12,7 +12,7 @@ if __name__ == "__main__":
 	keys.sort()
 	
 	for key in keys:
-		sys.stdout.write("%-20s: %s\n" % (key, os.environ[key]))
+		sys.stdout.write("%s=%s\n" % (key, os.environ[key]))
 		sys.stdout.flush()
 	
 	sys.stdout.write("Written process environment\n")

--- a/pysys-examples/internal/testcases/PySys_internal_024/Reference/ref_environment.out
+++ b/pysys-examples/internal/testcases/PySys_internal_024/Reference/ref_environment.out
@@ -1,6 +1,6 @@
 Writing process environment
-EMPTY-ENV           : 
-INT-ENV             : 1
-PYSYS-TEST          : Test variable
-PYSYS-USER          : Simon Batty
+EMPTY-ENV=
+INT-ENV=1
+PYSYS-TEST=Test variable
+PYSYS-USER=Simon Batty
 Written process environment

--- a/pysys-examples/internal/testcases/PySys_internal_024/run.py
+++ b/pysys-examples/internal/testcases/PySys_internal_024/run.py
@@ -60,7 +60,8 @@ class PySysTest(BaseTest):
 		self.assertDiff("environment-specified.out", "ref_environment.out", ignores=ignores)
 
 		# check we haven't copied any env vars from the parent environment other than the expected small minimal set
-		envvarignores = ['^%s='%x.upper() for x in 
-			['ComSpec', 'OS', 'PATHEXT', 'SystemRoot', 'SystemDrive', 'windir', 'NUMBER_OF_PROCESSORS']+['LD_LIBRARY_PATH', 'PATH']+ignores]
+		envvarignores = ['TEMP.*', 'TMP=']+['^%s='%x.upper() for x in 
+			['ComSpec', 'OS', 'PATHEXT', 'SystemRoot', 'SystemDrive', 'windir', 'NUMBER_OF_PROCESSORS']+[
+				'LD_LIBRARY_PATH', 'PATH']+ignores]
 		self.assertGrep('environment-default.out', expr='.*=', contains=False, ignores=envvarignores)
 		

--- a/pysys-examples/internal/testcases/PySys_internal_024/run.py
+++ b/pysys-examples/internal/testcases/PySys_internal_024/run.py
@@ -11,7 +11,7 @@ class PySysTest(BaseTest):
 		env["PYSYS-TEST"] = "Test variable"
 		env["EMPTY-ENV"] = ""
 		env["INT-ENV"] = "1"
-		env["PYTHONPATH"] = os.pathsep.join(sys.path)
+		#env["PYTHONPATH"] = os.pathsep.join(sys.path)
 
 		
 		if PLATFORM=='win32':
@@ -49,7 +49,7 @@ class PySysTest(BaseTest):
 	def validate(self):
 		# validate against the reference file
 
-		ignores=['SYSTEMROOT','LD_LIBRARY_PATH', 'PYTHONPATH']
+		ignores=['SYSTEMROOT','LD_LIBRARY_PATH']#, 'PYTHONPATH']
 		
 		if PLATFORM=='darwin':
 			ignores.append('VERSIONER_PYTHON')
@@ -59,12 +59,8 @@ class PySysTest(BaseTest):
 
 		self.assertDiff("environment-specified.out", "ref_environment.out", ignores=ignores)
 
-		# check we haven't copied all env vars from the parent environment
-		# (just a small minimal set required to make things work)
-		envvarignores = [
-			'$PATH=%s'%re.escape(PATH),
-			'$LD_LIBRARY_PATH=%s'%re.escape(LD_LIBRARY_PATH),
-			'$SYSTEMROOT=',
-			]
+		# check we haven't copied any env vars from the parent environment other than the expected small minimal set
+		envvarignores = ['^%s='%x.upper() for x in 
+			['ComSpec', 'OS', 'PATHEXT', 'SystemRoot', 'SystemDrive', 'windir', 'NUMBER_OF_PROCESSORS']+['LD_LIBRARY_PATH', 'PATH']+ignores]
 		self.assertGrep('environment-default.out', expr='.*=', contains=False, ignores=envvarignores)
 		

--- a/pysys-examples/internal/testcases/PySys_internal_024/run.py
+++ b/pysys-examples/internal/testcases/PySys_internal_024/run.py
@@ -62,6 +62,12 @@ class PySysTest(BaseTest):
 		envvarignores = []
 		envvarignores.extend(['TEMP.*', 'TMP.*=']) # set in default pysys config file
 
+		if IS_WINDOWS:
+			envvarignores.extend(['ComSpec', 'OS', 'PATHEXT', 'SystemRoot', 'SystemDrive', 'windir', 
+				'NUMBER_OF_PROCESSORS', 'PROCESSOR_ARCHITECTURE',
+				'COMMONPROGRAMFILES', 'COMMONPROGRAMFILES(X86)', 'PROGRAMFILES', 'PROGRAMFILES(X86)', 
+				'SYSTEM', 'SYSTEM32'])
+
 		envvarignores.extend(['^%s='%x.upper() for x in 
 			['ComSpec', 'OS', 'PATHEXT', 'SystemRoot', 'SystemDrive', 'windir', 'NUMBER_OF_PROCESSORS']+[
 				'LD_LIBRARY_PATH', 'PATH']+ignores])

--- a/pysys-examples/internal/testcases/PySys_internal_096/pysystest.xml
+++ b/pysys-examples/internal/testcases/PySys_internal_096/pysystest.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" standalone="yes"?>
+<pysystest type="auto" state="runnable">
+    
+  <description> 
+    <title>Doctests - utils.stringutils module</title>    
+    <purpose><![CDATA[
+Execute Python doctests
+]]>
+    </purpose>
+  </description>
+
+  <classification>
+    <groups>
+      <group>doctest</group>
+    </groups>
+  </classification>
+
+  <data>
+    <class name="PySysTest" module="run"/>
+  </data>
+ 
+</pysystest>

--- a/pysys-examples/internal/testcases/PySys_internal_096/pysystest.xml
+++ b/pysys-examples/internal/testcases/PySys_internal_096/pysystest.xml
@@ -2,7 +2,7 @@
 <pysystest type="auto" state="runnable">
     
   <description> 
-    <title>Doctests - utils.stringutils module</title>    
+    <title>Doctests - process.user module</title>    
     <purpose><![CDATA[
 Execute Python doctests
 ]]>

--- a/pysys-examples/internal/testcases/PySys_internal_096/run.py
+++ b/pysys-examples/internal/testcases/PySys_internal_096/run.py
@@ -1,22 +1,13 @@
+import os, sys
 import pysys
 from pysys.constants import *
 from pysys.basetest import BaseTest
-import os, sys
 
 class PySysTest(BaseTest):
 
 	def execute(self):
-		self.pythonDocTest(os.path.dirname(pysys.__file__)+'/utils/stringutils.py', 
+		self.pythonDocTest(os.path.dirname(pysys.__file__)+'/process/user.py', 
 			pythonPath=sys.path)
 			
 	def validate(self):
-		return
-		# ensure these appear at start of the line, which for some CI writers is important
-		self.assertGrep('pysys.out', expr='^stdoutPrint-CUSTOMWRITER-setup')
-		self.assertGrep('pysys.out', expr='^stdoutPrint-CUSTOMWRITER-processResult')
-		self.assertGrep('pysys.out', expr='^stdoutPrint-CUSTOMWRITER-setup')
-		
-		self.assertGrep('pysys.out', expr='^sys.stdout.write-CUSTOMWRITER-setup')
-		self.assertGrep('pysys.out', expr='^sys.stdout.write-CUSTOMWRITER-processResult')
-		self.assertGrep('pysys.out', expr='^sys.stdout.write-CUSTOMWRITER-setup')
-		
+		pass # all validation is done by pythonDocTest

--- a/pysys-examples/internal/testcases/PySys_internal_096/run.py
+++ b/pysys-examples/internal/testcases/PySys_internal_096/run.py
@@ -1,0 +1,22 @@
+import pysys
+from pysys.constants import *
+from pysys.basetest import BaseTest
+import os, sys
+
+class PySysTest(BaseTest):
+
+	def execute(self):
+		self.pythonDocTest(os.path.dirname(pysys.__file__)+'/utils/stringutils.py', 
+			pythonPath=sys.path)
+			
+	def validate(self):
+		return
+		# ensure these appear at start of the line, which for some CI writers is important
+		self.assertGrep('pysys.out', expr='^stdoutPrint-CUSTOMWRITER-setup')
+		self.assertGrep('pysys.out', expr='^stdoutPrint-CUSTOMWRITER-processResult')
+		self.assertGrep('pysys.out', expr='^stdoutPrint-CUSTOMWRITER-setup')
+		
+		self.assertGrep('pysys.out', expr='^sys.stdout.write-CUSTOMWRITER-setup')
+		self.assertGrep('pysys.out', expr='^sys.stdout.write-CUSTOMWRITER-processResult')
+		self.assertGrep('pysys.out', expr='^sys.stdout.write-CUSTOMWRITER-setup')
+		

--- a/pysys-examples/internal/testcases/PySys_internal_097/Input/PySys_NestedTestcase/Input/test.py
+++ b/pysys-examples/internal/testcases/PySys_internal_097/Input/PySys_NestedTestcase/Input/test.py
@@ -1,4 +1,4 @@
 import tempfile, os
 print('TempDir=%s'%os.path.normpath(tempfile.gettempdir()))
-print('Python environment: %s'%os.environ)
+print('Python environment: %s.'%', '.join(os.environ.keys()))
 print('Python executed successfully')

--- a/pysys-examples/internal/testcases/PySys_internal_097/Input/PySys_NestedTestcase/Input/test.py
+++ b/pysys-examples/internal/testcases/PySys_internal_097/Input/PySys_NestedTestcase/Input/test.py
@@ -1,3 +1,3 @@
-import tempfile
-print('TempDir=%s'%tempfile.gettempdir())
+import tempfile, os
+print('TempDir=%s'%os.path.normpath(tempfile.gettempdir()))
 print('Python executed successfully')

--- a/pysys-examples/internal/testcases/PySys_internal_097/Input/PySys_NestedTestcase/Input/test.py
+++ b/pysys-examples/internal/testcases/PySys_internal_097/Input/PySys_NestedTestcase/Input/test.py
@@ -1,4 +1,4 @@
 import tempfile, os
 print('TempDir=%s'%os.path.normpath(tempfile.gettempdir()))
-print('Python environment: %s.'%', '.join(os.environ.keys()))
+print('Python environment: %s.'%', '.join([k for k in os.environ.keys() if not k.startswith('LC_')]))
 print('Python executed successfully')

--- a/pysys-examples/internal/testcases/PySys_internal_097/Input/PySys_NestedTestcase/Input/test.py
+++ b/pysys-examples/internal/testcases/PySys_internal_097/Input/PySys_NestedTestcase/Input/test.py
@@ -1,4 +1,6 @@
 import tempfile, os
 print('TempDir=%s'%os.path.normpath(tempfile.gettempdir()))
-print('Python environment: %s.'%', '.join([k for k in os.environ.keys() if not k.startswith('LC_')]))
+print('Python environment: %s.'%', '.join([k for k in os.environ.keys() 
+	# some OSes e.g. mac define some internal ones like __PYVENV_LAUNCHER__ etc, and others some encoding-related ones
+	if not k.startswith('LC_') and not k.startswith('__')]))
 print('Python executed successfully')

--- a/pysys-examples/internal/testcases/PySys_internal_097/Input/PySys_NestedTestcase/Input/test.py
+++ b/pysys-examples/internal/testcases/PySys_internal_097/Input/PySys_NestedTestcase/Input/test.py
@@ -1,0 +1,3 @@
+import tempfile
+print('TempDir=%s'%tempfile.gettempdir())
+print('Python executed successfully')

--- a/pysys-examples/internal/testcases/PySys_internal_097/Input/PySys_NestedTestcase/Input/test.py
+++ b/pysys-examples/internal/testcases/PySys_internal_097/Input/PySys_NestedTestcase/Input/test.py
@@ -1,3 +1,4 @@
 import tempfile, os
 print('TempDir=%s'%os.path.normpath(tempfile.gettempdir()))
+print('Python environment: %s'%os.environ)
 print('Python executed successfully')

--- a/pysys-examples/internal/testcases/PySys_internal_097/Input/PySys_NestedTestcase/pysystest.xml
+++ b/pysys-examples/internal/testcases/PySys_internal_097/Input/PySys_NestedTestcase/pysystest.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" standalone="yes"?>
+<pysystest type="auto" state="runnable">
+    
+  <description> 
+    <title>Nested testcase</title>    
+    <purpose><![CDATA[
+
+]]>
+    </purpose>
+  </description>
+
+  <classification>
+    <groups>
+      <group>outcomes</group>
+    </groups>
+  </classification>
+
+  <data>
+    <class name="PySysTest" module="run"/>
+  </data>
+  
+  <traceability>
+    <requirements>
+      <requirement id=""/>     
+    </requirements>
+  </traceability>
+</pysystest>

--- a/pysys-examples/internal/testcases/PySys_internal_097/Input/PySys_NestedTestcase/run.py
+++ b/pysys-examples/internal/testcases/PySys_internal_097/Input/PySys_NestedTestcase/run.py
@@ -1,0 +1,26 @@
+from pysys.constants import *
+from pysys.basetest import BaseTest
+from pysys.exceptions import *
+import tempfile
+
+class PySysTest(BaseTest):
+	def execute(self):
+	
+		self.log.info('Temp dir = %s', tempfile.gettempdir())
+		assert os.path.exists(tempfile.gettempdir())
+		
+		env = self.getDefaultEnvirons()
+		with open(self.output+'/env.txt', 'w', encoding='utf-8') as f:
+			for k in sorted(env.keys()):
+				f.write('%s=%s\n'%(k, env[k]))
+
+		env = self.getDefaultEnvirons(command=sys.executable)
+		with open(self.output+'/env-python.txt', 'w', encoding='utf-8') as f:
+			for k in sorted(env.keys()):
+				f.write('%s=%s\n'%(k, env[k]))
+		
+		self.startProcess(command=sys.executable, arguments=[self.input+'/test.py'], 
+			stdout='python.out', stderr='python.err')#, ignoreExitStatus=True)
+
+	def validate(self):
+		pass 

--- a/pysys-examples/internal/testcases/PySys_internal_097/Input/PySys_NestedTestcase/run.py
+++ b/pysys-examples/internal/testcases/PySys_internal_097/Input/PySys_NestedTestcase/run.py
@@ -1,23 +1,24 @@
 from pysys.constants import *
 from pysys.basetest import BaseTest
 from pysys.exceptions import *
+from pysys.utils.pycompat import openfile
 import tempfile
 
 class PySysTest(BaseTest):
 	def execute(self):
 	
-		self.log.info('Temp dir = %s', tempfile.gettempdir())
+		self.log.info(u'Temp dir = %s', tempfile.gettempdir())
 		assert os.path.exists(tempfile.gettempdir())
 		
 		env = self.getDefaultEnvirons()
-		with open(self.output+'/env.txt', 'w', encoding='utf-8') as f:
+		with openfile(self.output+'/env.txt', 'w', encoding='utf-8') as f:
 			for k in sorted(env.keys()):
-				f.write('%s=%s\n'%(k, env[k]))
+				f.write(u'%s=%s\n'%(k, env[k]))
 
 		env = self.getDefaultEnvirons(command=sys.executable)
-		with open(self.output+'/env-python.txt', 'w', encoding='utf-8') as f:
+		with openfile(self.output+'/env-python.txt', 'w', encoding='utf-8') as f:
 			for k in sorted(env.keys()):
-				f.write('%s=%s\n'%(k, env[k]))
+				f.write(u'%s=%s\n'%(k, env[k]))
 		
 		self.startProcess(command=sys.executable, arguments=[self.input+'/test.py'], 
 			stdout='python.out', stderr='python.err')#, ignoreExitStatus=True)

--- a/pysys-examples/internal/testcases/PySys_internal_097/Input/pysysproject-lang.xml
+++ b/pysys-examples/internal/testcases/PySys_internal_097/Input/pysysproject-lang.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" standalone="yes"?>
+<pysysproject>
+	<property environment="env"/>
+
+	<property osfamily="osfamily"/>
+
+	<property name="defaultEnvironsDefaultLang" value="my-lang"/>
+
+	
+</pysysproject>

--- a/pysys-examples/internal/testcases/PySys_internal_097/Input/pysysproject-legacy.xml
+++ b/pysys-examples/internal/testcases/PySys_internal_097/Input/pysysproject-legacy.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" standalone="yes"?>
+<pysysproject>
+	<property environment="env"/>
+
+	<property osfamily="osfamily"/>
+
+	<property name="defaultAbortOnError" value="true"/>
+	<property name="defaultEnvironsLegacyMode" value="true"/>
+
+	
+</pysysproject>

--- a/pysys-examples/internal/testcases/PySys_internal_097/Input/pysysproject-none.xml
+++ b/pysys-examples/internal/testcases/PySys_internal_097/Input/pysysproject-none.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" standalone="yes"?>
+<pysysproject>
+	<property environment="env"/>
+
+	<property osfamily="osfamily"/>
+
+	<property name="defaultAbortOnError" value="true"/>
+	
+</pysysproject>

--- a/pysys-examples/internal/testcases/PySys_internal_097/Input/pysysproject-tempdir.xml
+++ b/pysys-examples/internal/testcases/PySys_internal_097/Input/pysysproject-tempdir.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" standalone="yes"?>
+<pysysproject>
+	<property environment="env"/>
+
+	<property osfamily="osfamily"/>
+
+	<property name="defaultAbortOnError" value="true"/>
+	<property name="defaultEnvironsTempDir" value="self.output+'/mytemp'"/>
+
+	
+</pysysproject>

--- a/pysys-examples/internal/testcases/PySys_internal_097/pysystest.xml
+++ b/pysys-examples/internal/testcases/PySys_internal_097/pysystest.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" standalone="yes"?>
+<pysystest type="auto" state="runnable">
+    
+  <description> 
+    <title>Process - getDefaultEnvirons configuration options</title>    
+    <purpose><![CDATA[
+Check that project configuration options affecting getDefaultEnvirons do the right thing. 
+]]>
+    </purpose>
+  </description>
+
+  <classification>
+    <groups>
+      <group>process</group>
+    </groups>
+  </classification>
+
+  <data>
+    <class name="PySysTest" module="run"/>
+  </data>
+  
+  <traceability>
+    <requirements>
+      <requirement id=""/>     
+    </requirements>
+  </traceability>
+</pysystest>

--- a/pysys-examples/internal/testcases/PySys_internal_097/run.py
+++ b/pysys-examples/internal/testcases/PySys_internal_097/run.py
@@ -29,10 +29,10 @@ class PySysTest(BaseTest):
 		else:
 			# depending on where python is installed, empty environment might mean we can't even start python
 			# or it might start and print an empty environment
-			if os.path.exists(self.output+'/pysys-legacy/PySys_NestedTestcase/env.txt'):
-				self.assertGrep('pysys-legacy/PySys_NestedTestcase/env.txt', expr='.+', contains=False)
-			else:
+			if os.path.exists(self.output+'/pysys-legacy/PySys_NestedTestcase/python.err'):
 				self.assertGrep('pysys-legacy/PySys_NestedTestcase/python.err', expr='.+')
+			else:
+				self.assertGrep('pysys-legacy/PySys_NestedTestcase/python.out', expr='Python environment: [{][}]')
 
 		# python setting - affects PYTHONHOME, LD_LIB and executable PATH
 		if IS_WINDOWS:

--- a/pysys-examples/internal/testcases/PySys_internal_097/run.py
+++ b/pysys-examples/internal/testcases/PySys_internal_097/run.py
@@ -1,0 +1,49 @@
+import pysys
+from pysys.constants import *
+from pysys.basetest import BaseTest
+from pysys.utils.perfreporter import CSVPerformanceFile
+import os, sys, math, shutil
+
+class PySysTest(BaseTest):
+
+	def execute(self):
+		l = {}
+		exec(open(os.path.normpath(self.input+'/../../../utilities/resources/runpysys.py')).read(), {}, l) # define runPySys
+		runPySys = l['runPySys']
+		
+		shutil.copytree(self.input, self.output+'/test')
+		
+		for subtest in ['none', 'lang', 'legacy', 'tempdir']:
+			runPySys(self, 'pysys', ['run', '-o', self.output+'/pysys-'+subtest], workingDir='test', 
+				environs={'SOME_OVERRIDE':'some value'},
+				projectfile='pysysproject-%s.xml'%subtest)
+			self.logFileContents('pysys-%s.out'%subtest, maxLines=0)
+			
+	def validate(self):
+		# inherited environment not passed on, unles in legacy mode on Windows
+		self.assertGrep('pysys-none/PySys_NestedTestcase/env.txt', expr='SOME_OVERRIDE=', contains=False)
+		if IS_WINDOWS:
+			self.assertGrep('pysys-legacy/PySys_NestedTestcase/env.txt', expr='SOME_OVERRIDE=some value')
+			self.assertGrep('pysys-legacy/PySys_NestedTestcase/env.txt', expr='PATHEXT=')
+		else:
+			# empty environment
+			self.assertGrep('pysys-legacy/PySys_NestedTestcase/env.txt', expr='.', contains=False)
+
+		# python setting
+		if IS_WINDOWS:
+			self.assertGrep('pysys-none/PySys_NestedTestcase/env.txt', expr='python', contains=False)
+			self.assertGrep('pysys-none/PySys_NestedTestcase/env-python.txt', expr='LD_LIBRARY', contains=False)
+			self.assertGrep('pysys-none/PySys_NestedTestcase/env-python.txt', expr='PATH=.*python')
+		else:
+			self.assertGrep('pysys-none/PySys_NestedTestcase/env.txt', expr='python', contains=False)
+			self.assertGrep('pysys-none/PySys_NestedTestcase/env-python.txt', expr='PATH=.*python', contains=False)
+			self.assertGrep('pysys-none/PySys_NestedTestcase/env-python.txt', expr='LD_LIBRARY_PATH=.*python')
+		self.assertGrep('pysys-none/PySys_NestedTestcase/python.out', expr='Python executed successfully')
+
+		self.assertTrue(os.path.exists(self.output+'/pysys-tempdir/PySys_NestedTestcase/mytemp'), assertMessage='tempdir was created')
+		self.assertGrep('pysys-tempdir/PySys_NestedTestcase/python.out', expr='TempDir=.*PySys_NestedTestcase.mytemp')
+
+		if IS_WINDOWS:
+			self.assertGrep('pysys-lang/PySys_NestedTestcase/env.txt', expr='LANG', contains=False)
+		else:
+			self.assertGrep('pysys-lang/PySys_NestedTestcase/env.txt', expr='LANG=my-lang')

--- a/pysys-examples/internal/testcases/PySys_internal_097/run.py
+++ b/pysys-examples/internal/testcases/PySys_internal_097/run.py
@@ -41,7 +41,7 @@ class PySysTest(BaseTest):
 		self.assertGrep('pysys-none/PySys_NestedTestcase/python.out', expr='Python executed successfully')
 
 		self.assertTrue(os.path.exists(self.output+'/pysys-tempdir/PySys_NestedTestcase/mytemp'), assertMessage='tempdir was created')
-		self.assertGrep('pysys-tempdir/PySys_NestedTestcase/python.out', expr='TempDir=.*PySys_NestedTestcase.mytemp')
+		self.assertGrep('pysys-tempdir/PySys_NestedTestcase/python.out', expr='TempDir=.*[Nn]ested[Tt]estcase.mytemp')
 
 		if IS_WINDOWS:
 			self.assertGrep('pysys-lang/PySys_NestedTestcase/env.txt', expr='LANG', contains=False)

--- a/pysys-examples/internal/testcases/PySys_internal_097/run.py
+++ b/pysys-examples/internal/testcases/PySys_internal_097/run.py
@@ -28,6 +28,7 @@ class PySysTest(BaseTest):
 			self.assertGrep('pysys-legacy/PySys_NestedTestcase/env.txt', expr='PATHEXT=')
 		else:
 			# empty environment means we can't even start python
+			self.logFileContents('pysys-legacy/PySys_NestedTestcase/run.log')
 			self.assertGrep('pysys-legacy/PySys_NestedTestcase/python.err', expr='.')
 			#self.assertGrep('pysys-legacy/PySys_NestedTestcase/env.txt', expr='.', contains=False)
 
@@ -38,7 +39,8 @@ class PySysTest(BaseTest):
 			self.assertGrep('pysys-none/PySys_NestedTestcase/env-python.txt', expr='PATH=.*python')
 		else:
 			self.assertGrep('pysys-none/PySys_NestedTestcase/env.txt', expr='python', contains=False)
-			self.assertGrep('pysys-none/PySys_NestedTestcase/env-python.txt', expr='LD_LIBRARY_PATH=.*python')
+			self.assertGrep('pysys-none/PySys_NestedTestcase/env-python.txt', expr='LD_LIBRARY_PATH=.+')
+			self.logFileContents('pysys-none/PySys_NestedTestcase/env-python.txt')
 		self.assertGrep('pysys-none/PySys_NestedTestcase/python.out', expr='Python executed successfully')
 
 		self.assertTrue(os.path.exists(self.output+'/pysys-tempdir/PySys_NestedTestcase/mytemp'), assertMessage='tempdir was created')

--- a/pysys-examples/internal/testcases/PySys_internal_097/run.py
+++ b/pysys-examples/internal/testcases/PySys_internal_097/run.py
@@ -36,10 +36,11 @@ class PySysTest(BaseTest):
 				self.assertGrep('pysys-legacy/PySys_NestedTestcase/python.out', expr='Python environment: [.]')
 
 		# python setting - affects PYTHONHOME, LD_LIB and executable PATH
+		self.logFileContents('pysys-none/PySys_NestedTestcase/env-python.txt')
 		if IS_WINDOWS:
 			self.assertGrep('pysys-none/PySys_NestedTestcase/env.txt', expr='python', contains=False)
 			self.assertGrep('pysys-none/PySys_NestedTestcase/env-python.txt', expr='LD_LIBRARY', contains=False)
-			self.assertGrep('pysys-none/PySys_NestedTestcase/env-python.txt', expr='PATH=.*python')
+			self.assertGrep('pysys-none/PySys_NestedTestcase/env-python.txt', expr='PATH=.+')
 		else:
 			self.assertGrep('pysys-none/PySys_NestedTestcase/env.txt', expr='python', contains=False)
 			self.assertGrep('pysys-none/PySys_NestedTestcase/env-python.txt', expr='LD_LIBRARY_PATH=.+')

--- a/pysys-examples/internal/testcases/PySys_internal_097/run.py
+++ b/pysys-examples/internal/testcases/PySys_internal_097/run.py
@@ -27,10 +27,12 @@ class PySysTest(BaseTest):
 			self.assertGrep('pysys-legacy/PySys_NestedTestcase/env.txt', expr='SOME_OVERRIDE=some value')
 			self.assertGrep('pysys-legacy/PySys_NestedTestcase/env.txt', expr='PATHEXT=')
 		else:
-			# empty environment means we can't even start python
-			self.logFileContents('pysys-legacy/PySys_NestedTestcase/run.log')
-			self.assertGrep('pysys-legacy/PySys_NestedTestcase/python.err', expr='.')
-			#self.assertGrep('pysys-legacy/PySys_NestedTestcase/env.txt', expr='.', contains=False)
+			# depending on where python is installed, empty environment might mean we can't even start python
+			# or it might start and print an empty environment
+			if os.path.exists(self.output+'/pysys-legacy/PySys_NestedTestcase/env.txt'):
+				self.assertGrep('pysys-legacy/PySys_NestedTestcase/env.txt', expr='.+', contains=False)
+			else:
+				self.assertGrep('pysys-legacy/PySys_NestedTestcase/python.err', expr='.+')
 
 		# python setting - affects PYTHONHOME, LD_LIB and executable PATH
 		if IS_WINDOWS:

--- a/pysys-examples/internal/testcases/PySys_internal_097/run.py
+++ b/pysys-examples/internal/testcases/PySys_internal_097/run.py
@@ -33,7 +33,7 @@ class PySysTest(BaseTest):
 				self.assertGrep('pysys-legacy/PySys_NestedTestcase/python.err', expr='.+')
 			else:
 				self.logFileContents('pysys-legacy/PySys_NestedTestcase/python.out')
-				self.assertGrep('pysys-legacy/PySys_NestedTestcase/python.out', expr='Python environment: [{][}]')
+				self.assertGrep('pysys-legacy/PySys_NestedTestcase/python.out', expr='Python environment: [.]')
 
 		# python setting - affects PYTHONHOME, LD_LIB and executable PATH
 		if IS_WINDOWS:

--- a/pysys-examples/internal/testcases/PySys_internal_097/run.py
+++ b/pysys-examples/internal/testcases/PySys_internal_097/run.py
@@ -22,21 +22,22 @@ class PySysTest(BaseTest):
 	def validate(self):
 		# inherited environment not passed on, unles in legacy mode on Windows
 		self.assertGrep('pysys-none/PySys_NestedTestcase/env.txt', expr='SOME_OVERRIDE=', contains=False)
+
 		if IS_WINDOWS:
 			self.assertGrep('pysys-legacy/PySys_NestedTestcase/env.txt', expr='SOME_OVERRIDE=some value')
 			self.assertGrep('pysys-legacy/PySys_NestedTestcase/env.txt', expr='PATHEXT=')
 		else:
-			# empty environment
-			self.assertGrep('pysys-legacy/PySys_NestedTestcase/env.txt', expr='.', contains=False)
+			# empty environment means we can't even start python
+			self.assertGrep('pysys-legacy/PySys_NestedTestcase/python.err', expr='.')
+			#self.assertGrep('pysys-legacy/PySys_NestedTestcase/env.txt', expr='.', contains=False)
 
-		# python setting
+		# python setting - affects PYTHONHOME, LD_LIB and executable PATH
 		if IS_WINDOWS:
 			self.assertGrep('pysys-none/PySys_NestedTestcase/env.txt', expr='python', contains=False)
 			self.assertGrep('pysys-none/PySys_NestedTestcase/env-python.txt', expr='LD_LIBRARY', contains=False)
 			self.assertGrep('pysys-none/PySys_NestedTestcase/env-python.txt', expr='PATH=.*python')
 		else:
 			self.assertGrep('pysys-none/PySys_NestedTestcase/env.txt', expr='python', contains=False)
-			self.assertGrep('pysys-none/PySys_NestedTestcase/env-python.txt', expr='PATH=.*python', contains=False)
 			self.assertGrep('pysys-none/PySys_NestedTestcase/env-python.txt', expr='LD_LIBRARY_PATH=.*python')
 		self.assertGrep('pysys-none/PySys_NestedTestcase/python.out', expr='Python executed successfully')
 

--- a/pysys-examples/internal/testcases/PySys_internal_097/run.py
+++ b/pysys-examples/internal/testcases/PySys_internal_097/run.py
@@ -32,6 +32,7 @@ class PySysTest(BaseTest):
 			if os.path.exists(self.output+'/pysys-legacy/PySys_NestedTestcase/python.err'):
 				self.assertGrep('pysys-legacy/PySys_NestedTestcase/python.err', expr='.+')
 			else:
+				self.logFileContents('pysys-legacy/PySys_NestedTestcase/python.out')
 				self.assertGrep('pysys-legacy/PySys_NestedTestcase/python.out', expr='Python environment: [{][}]')
 
 		# python setting - affects PYTHONHOME, LD_LIB and executable PATH

--- a/pysys-examples/internal/utilities/resources/runpysys.py
+++ b/pysys-examples/internal/utilities/resources/runpysys.py
@@ -10,7 +10,8 @@ def runPySys(processowner, stdouterr, args, ignoreExitStatus=False, abortOnError
 		args = ['-m', 'pysys']+args
 
 	# allow controlling lang from the parent e.g. via Travis, if not explicitly set
-	if not IS_WINDOWS and 'LANG' not in environs and 'LANG' in os.environ: 
+	if not IS_WINDOWS and 'LANG' not in (environs or {}) and 'LANG' in os.environ: 
+		environs = dict(environs or {})
 		environs['LANG'] = os.environ['LANG']
 		if environs['LANG'] == 'C':
 			environs['LANGUAGE'] = 'C'

--- a/pysys-examples/internal/utilities/resources/runpysys.py
+++ b/pysys-examples/internal/utilities/resources/runpysys.py
@@ -9,20 +9,20 @@ def runPySys(processowner, stdouterr, args, ignoreExitStatus=False, abortOnError
 	else:
 		args = ['-m', 'pysys']+args
 
-	environs = processowner.createEnvirons(overrides=environs, command=sys.executable)
-	
-	if projectfile:
-		environs['PYSYS_PROJECTFILE'] = os.path.join(processowner.input, projectfile)
-	
-	# allow controlling lang from the parent e.g. via Travis
-	if not IS_WINDOWS: 
-		environs['LANG'] = os.getenv('LANG','en_US.UTF-8')
+	# allow controlling lang from the parent e.g. via Travis, if not explicitly set
+	if not IS_WINDOWS and 'LANG' not in environs and 'LANG' in os.environ: 
+		environs['LANG'] = os.environ['LANG']
 		if environs['LANG'] == 'C':
 			environs['LANGUAGE'] = 'C'
 			environs['LC_ALL'] = 'C'
 			environs['PYTHONUTF8'] = '0'
 			environs['PYTHONCOERCECLOCALE'] = '0'
-			
+
+	environs = processowner.createEnvirons(overrides=environs, command=sys.executable)
+	
+	if projectfile:
+		environs['PYSYS_PROJECTFILE'] = os.path.join(processowner.input, projectfile)
+	
 	# since we might be running this from not an installation
 	environs['PYTHONPATH'] = os.pathsep.join(sys.path)
 

--- a/pysys-examples/internal/utilities/resources/runpysys.py
+++ b/pysys-examples/internal/utilities/resources/runpysys.py
@@ -1,24 +1,24 @@
-def runPySys(processowner, stdouterr, args, ignoreExitStatus=False, abortOnError=True, environs=None, **kwargs):
+def runPySys(processowner, stdouterr, args, ignoreExitStatus=False, abortOnError=True, environs=None, projectfile=None, **kwargs):
 	"""
 	Executes pysys from within pysys. Used only by internal pysys testcases. 
 	"""
 	import os, sys
+	from pysys.constants import IS_WINDOWS
 	if sys.argv[0].endswith('pysys.py'):
 		args = [os.path.abspath(sys.argv[0])]+args
 	else:
 		args = ['-m', 'pysys']+args
-	env = dict(environs or {})
-	for k in os.environ: 
-		# don't preserve any env vars from parent env that might affect test behaviour
-		if k not in env and not k.startswith('PYSYS_') and \
-			k not in ['TRAVIS']: env[k] = os.environ[k]
-	for k in list(env.keys()):
-		if env[k] == None: env.pop(k)
-	pypath = os.path.dirname(sys.executable)
-	if not env.get('PATH','').startswith(pypath+os.pathsep):
-		# whatever python we're using, make sure it's on path, otherwise in some cases child pythons don't have sys.executable set
-		env['PATH'] = pypath+os.pathsep+env.get('PATH','')
-			
+
+	environs = processowner.createEnvirons(overrides=environs, command=sys.executable)
+	
+	if projectfile:
+		environs['PYSYS_PROJECTFILE'] = os.path.join(processowner.input, projectfile)
+	
+	# allow controlling lang from the parent e.g. via Travis
+	if not IS_WINDOWS: environs['LANG'] = os.getenv('LANG','en_US.UTF-8')
+	# since we might be running this from not an installation
+	environs['PYTHONPATH'] = os.pathsep.join(sys.path)
+
 	try: 
 		import coverage
 	except ImportError: pass
@@ -30,7 +30,8 @@ def runPySys(processowner, stdouterr, args, ignoreExitStatus=False, abortOnError
 	try:
 		return processowner.startProcess(command=sys.executable,
 			arguments = args,
-			environs = env, ignoreExitStatus=ignoreExitStatus, abortOnError=abortOnError, 
+			environs = environs,
+			ignoreExitStatus=ignoreExitStatus, abortOnError=abortOnError, 
 			stdout=stdouterr+'.out', stderr=stdouterr+'.err', 
 			displayName='pysys %s'%stdouterr, 
 			**kwargs)

--- a/pysys-examples/internal/utilities/resources/runpysys.py
+++ b/pysys-examples/internal/utilities/resources/runpysys.py
@@ -15,7 +15,14 @@ def runPySys(processowner, stdouterr, args, ignoreExitStatus=False, abortOnError
 		environs['PYSYS_PROJECTFILE'] = os.path.join(processowner.input, projectfile)
 	
 	# allow controlling lang from the parent e.g. via Travis
-	if not IS_WINDOWS: environs['LANG'] = os.getenv('LANG','en_US.UTF-8')
+	if not IS_WINDOWS: 
+		environs['LANG'] = os.getenv('LANG','en_US.UTF-8')
+		if environs['LANG'] == 'C':
+			environs['LANGUAGE'] = 'C'
+			environs['LC_ALL'] = 'C'
+			environs['PYTHONUTF8'] = '0'
+			environs['PYTHONCOERCECLOCALE'] = '0'
+			
 	# since we might be running this from not an installation
 	environs['PYTHONPATH'] = os.pathsep.join(sys.path)
 

--- a/pysys-examples/pysysproject.xml
+++ b/pysys-examples/pysysproject.xml
@@ -130,7 +130,7 @@
 	Set temporary directory for child processes to the testcase output 
 	directory to avoid cluttering up common file locations. 
 	-->
-	<property name="defaultEnvironsTempDir" value="self.output'"/>
+	<property name="defaultEnvironsTempDir" value="self.output"/>
 
 
 	<!-- 

--- a/pysys-examples/pysysproject.xml
+++ b/pysys-examples/pysysproject.xml
@@ -91,7 +91,7 @@
 
 
 	<!-- 
-	Controls whether tests will abort as a fail as soon as an assert, process, or wait operation
+	Controls whether tests will abort as a fail as soon as a process or wait operation
 	completes with errors. The default value as specified below will be used when the abortOnError 
 	parameter to the function is not specified. 
 	-->

--- a/pysys-examples/pysysproject.xml
+++ b/pysys-examples/pysysproject.xml
@@ -95,7 +95,7 @@
 	completes with errors. The default value as specified below will be used when the abortOnError 
 	parameter to the function is not specified. 
 	-->
-	<property name="defaultAbortOnError" value="false"/>	
+	<property name="defaultAbortOnError" value="true"/>	
 
 
 	<!-- 

--- a/pysys-examples/pysysproject.xml
+++ b/pysys-examples/pysysproject.xml
@@ -120,7 +120,19 @@
 	-->
 	<property name="redirectPrintToLogger" value="false"/>
 	
-	
+
+	<!-- 
+	Set default LANG for child processes on Unix. 
+	-->
+	<property name="defaultEnvironsDefaultLang" value="en_US.UTF-8"/>
+
+	<!-- 
+	Set temporary directory for child processes to the testcase output 
+	directory to avoid cluttering up common file locations. 
+	-->
+	<property name="defaultEnvironsTempDir" value="self.output'"/>
+
+
 	<!-- 
 	Import properties from file (fails silently if the file does not exist). The imported 
 	file should be of the format name=value (one pair specified per line). Any imported names

--- a/pysys-examples/pysysproject.xml
+++ b/pysys-examples/pysysproject.xml
@@ -43,7 +43,7 @@
 	<!--
 	Specify a minimum required pysys version to run these tests
 	-->
-	<requires-pysys>1.3.0</requires-pysys>
+	<requires-pysys>1.4.0</requires-pysys>
 
 
 	<!--

--- a/pysys/basetest.py
+++ b/pysys/basetest.py
@@ -341,7 +341,7 @@ class BaseTest(ProcessUser):
 		@param args: Zero or more arguments to be substituted into the format 
 		string
 		
-		@param abortOnError: Set to True to make the test immediately abort if the
+		@param kwargs: can include only `abortOnError`: Set to True to make the test immediately abort if the
 		assertion fails. 
 
 		"""

--- a/pysys/basetest.py
+++ b/pysys/basetest.py
@@ -322,7 +322,7 @@ class BaseTest(ProcessUser):
 
 
 	# test validation methods.
-	def assertThat(self, conditionstring, *args, abortOnError=False):
+	def assertThat(self, conditionstring, *args, **kwargs):
 		"""Perform a validation based on a python eval string.
 
 		The eval string should be specified as a format string, with zero or more %s-style
@@ -345,6 +345,8 @@ class BaseTest(ProcessUser):
 		assertion fails. 
 
 		"""
+		abortOnError = kwargs.pop('abortOnError',False)
+		assert not kwargs, 'Invalid keyword arguments: %s'%kwargs.keys()
 		try:
 			expr = conditionstring
 			if args:

--- a/pysys/constants.py
+++ b/pysys/constants.py
@@ -49,6 +49,7 @@ if re.search('win32', sys.platform):
 	PATH = r'%s;%s\system32;%s\System32\Wbem' % (WINDIR, WINDIR, WINDIR)
 	LD_LIBRARY_PATH = ''
 	DYLD_LIBRARY_PATH = ''
+	LIBRARY_PATH_ENV_VAR = 'PATH'
 	SITE_PACKAGES_DIR =  os.path.join(sys.prefix, "Lib", "site-packages")
 	
 elif re.search('sunos', sys.platform):
@@ -58,6 +59,7 @@ elif re.search('sunos', sys.platform):
 	PATH = '/bin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/ccs/bin:/usr/openwin/bin:/opt/SUNWspro/bin'
 	LD_LIBRARY_PATH = '/usr/local/lib' 
 	DYLD_LIBRARY_PATH = ''
+	LIBRARY_PATH_ENV_VAR = 'LD_LIBRARY_PATH'
 	SITE_PACKAGES_DIR = os.path.join(sys.prefix, "lib", "python%s" % sys.version[:3], "site-packages")
 
 elif re.search('linux', sys.platform):
@@ -67,6 +69,7 @@ elif re.search('linux', sys.platform):
 	PATH = '/bin:/usr/bin:/usr/sbin:/usr/local/bin'
 	LD_LIBRARY_PATH = '/usr/lib'
 	DYLD_LIBRARY_PATH = ''
+	LIBRARY_PATH_ENV_VAR = 'LD_LIBRARY_PATH'
 	SITE_PACKAGES_DIR = os.path.join(sys.prefix, "lib", "python%s" % sys.version[:3], "site-packages")
 
 elif re.search('darwin', sys.platform):
@@ -76,8 +79,8 @@ elif re.search('darwin', sys.platform):
 	PATH = '/bin:/usr/bin:/usr/sbin:/usr/local/bin'
 	LD_LIBRARY_PATH = ''
 	DYLD_LIBRARY_PATH = '/usr/lib:/usr/local/lib'
+	LIBRARY_PATH_ENV_VAR = 'DYLD_LIBRARY_PATH'
 	SITE_PACKAGES_DIR = os.path.join(sys.prefix, "lib", "python%s" % sys.version[:3], "site-packages")
-
 else:
 	# Fall back to assumed UNIX-like platform
 	PLATFORM=sys.platform
@@ -86,6 +89,7 @@ else:
 	PATH = '/bin:/usr/bin:/usr/sbin:/usr/local/bin'
 	LD_LIBRARY_PATH = '/usr/lib'
 	DYLD_LIBRARY_PATH = ''
+	LIBRARY_PATH_ENV_VAR = 'LD_LIBRARY_PATH'
 	SITE_PACKAGES_DIR = os.path.join(sys.prefix, "lib", "python%s" % sys.version[:3], "site-packages")
 
 ENVSEPERATOR = os.pathsep

--- a/pysys/process/commonwrapper.py
+++ b/pysys/process/commonwrapper.py
@@ -41,14 +41,23 @@ def _stringToUnicode(s):
 class CommonProcessWrapper(object):
 	"""Abstract base process wrapper class for process execution and management.
 	
-	A base implementation of common process related operations, which should be extended
+	A base implementation of common process related operations, which is extended
 	by the OS specific wrapper classes.
 
 	@ivar pid: The process id for a running or complete process (as set by the OS)
 	@type pid: integer
+	
 	@ivar exitStatus: The process exit status for a completed process	
 	@type exitStatus: integer
 	
+	@ivar stdout: The full path to the filename to write the stdout of the process
+	@type stdout: string
+
+	@ivar stderr: The full path to the filename to write the stderr of the process
+	@type stderr: string
+
+	@ivar displayName: Display name for this process
+	@type displayName: string
 	"""
 
 	def __init__(self, command, arguments, environs, workingDir, state, timeout, stdout=None, stderr=None, displayName=None):
@@ -60,8 +69,8 @@ class CommonProcessWrapper(object):
 		@param workingDir:  The working directory for the process
 		@param state:  The state of the process (L{pysys.constants.FOREGROUND} or L{pysys.constants.BACKGROUND}
 		@param timeout:  The timeout in seconds to be applied to the process
-		@param stdout:  The full path to the filename to write the stdout of the process
-		@param stderr:  The full path to the filename to write the sdterr of the process
+		@param stdout:  The full path to the filename to write the stdout of the process, or None for no output
+		@param stderr:  The full path to the filename to write the sdterr of the process, or None for no output
 		@param displayName: Display name for this process
 
 		"""
@@ -77,6 +86,10 @@ class CommonProcessWrapper(object):
 		# 'publicly' available data attributes set on execution
 		self.pid = None
 		self.exitStatus = None
+		
+		# these may be further updated by the subclass
+		self.stdout = stdout
+		self.stderr = stderr
 
 		# print process debug information
 		log.debug("Process parameters for executable %s" % os.path.basename(self.command))

--- a/pysys/process/commonwrapper.py
+++ b/pysys/process/commonwrapper.py
@@ -65,7 +65,9 @@ class CommonProcessWrapper(object):
 		
 		@param command:  The full path to the command to execute
 		@param arguments:  A list of arguments to the command
-		@param environs:  A dictionary of environment variables (key, value) for the process context execution
+		@param environs:  A dictionary of environment variables (key, value) for the process context execution. 
+		Use unicode strings rather than byte strings if possible; on Python 2 byte strings are converted 
+		automatically to unicode using utf-8. 
 		@param workingDir:  The working directory for the process
 		@param state:  The state of the process (L{pysys.constants.FOREGROUND} or L{pysys.constants.BACKGROUND}
 		@param timeout:  The timeout in seconds to be applied to the process

--- a/pysys/process/plat-unix/helper.py
+++ b/pysys/process/plat-unix/helper.py
@@ -53,6 +53,12 @@ class ProcessWrapper(CommonProcessWrapper):
 	@type pid: integer
 	@ivar exitStatus: The process exit status for a completed process	
 	@type exitStatus: integer
+
+	@ivar stdout: The full path to the filename to write the stdout of the process
+	@type stdout: string
+
+	@ivar stderr: The full path to the filename to write the stderr of the process
+	@type stderr: string
 	
 	"""
 
@@ -73,16 +79,8 @@ class ProcessWrapper(CommonProcessWrapper):
 		CommonProcessWrapper.__init__(self, command, arguments, environs, workingDir, 
 			state, timeout, stdout, stderr, displayName, **kwargs)
 		
-		self.stdout = '/dev/null'
-		self.stderr = '/dev/null'
-		try:
-			if stdout is not None: self.stdout = stdout
-		except Exception:
-			log.info('Unable to create file to capture stdout - using the null device')
-		try:
-			if stderr is not None: self.stderr = stderr
-		except Exception:
-			log.info('Unable to create file to capture stdout - using the null device')
+		if self.stdout is None: self.stdout = '/dev/null'
+		if self.stderr is None: self.stderr = '/dev/null'
 
 		# private instance variables
 		self.__lock = threading.Lock() # to protect access to the fields that get updated while process is running

--- a/pysys/process/plat-win32/helper.py
+++ b/pysys/process/plat-win32/helper.py
@@ -87,18 +87,13 @@ class ProcessWrapper(CommonProcessWrapper):
 		
 		self.__lock = threading.Lock() # to protect access to the fields that get updated
 		
-		# set the stdout|err file handles
-		self.fStdout = 'nul'
-		self.fStderr = 'nul'
-		try:
-			if stdout is not None: self.fStdout = _stringToUnicode(stdout)
-		except Exception:
-			log.info("Unable to create file to capture stdout - using the null device")
-		try:
-			if stderr is not None: self.fStderr = _stringToUnicode(stderr)
-		except Exception:
-			log.info("Unable to create file to capture stdout - using the null device")
+		# on Python 2, convert byte strings to unicode strings
+		self.stdout = u'nul' if (not self.stdout) else _stringToUnicode(stdout)
+		self.stderr = u'nul' if (not self.stderr) else _stringToUnicode(stderr)
 
+		# these different field names are just retained for compatibility in case anyone is using them
+		self.fStdout = self.stdout
+		self.fStderr = self.stderr
 
 	def writeStdin(self):
 		"""Method to write to the process stdin pipe.
@@ -133,10 +128,10 @@ class ProcessWrapper(CommonProcessWrapper):
 	
 			# create pipes for the process to write to
 			hStdin_r, hStdin = win32pipe.CreatePipe(sAttrs, 0)
-			hStdout = win32file.CreateFile(_stringToUnicode(self.fStdout), win32file.GENERIC_WRITE | win32file.GENERIC_READ,
+			hStdout = win32file.CreateFile(_stringToUnicode(self.stdout), win32file.GENERIC_WRITE | win32file.GENERIC_READ,
 			   win32file.FILE_SHARE_DELETE | win32file.FILE_SHARE_READ | win32file.FILE_SHARE_WRITE,
 			   sAttrs, win32file.CREATE_ALWAYS, win32file.FILE_ATTRIBUTE_NORMAL, None)
-			hStderr = win32file.CreateFile(_stringToUnicode(self.fStderr), win32file.GENERIC_WRITE | win32file.GENERIC_READ,
+			hStderr = win32file.CreateFile(_stringToUnicode(self.stderr), win32file.GENERIC_WRITE | win32file.GENERIC_READ,
 			   win32file.FILE_SHARE_DELETE | win32file.FILE_SHARE_READ | win32file.FILE_SHARE_WRITE,
 			   sAttrs, win32file.CREATE_ALWAYS, win32file.FILE_ATTRIBUTE_NORMAL, None)
 

--- a/pysys/process/plat-win32/helper.py
+++ b/pysys/process/plat-win32/helper.py
@@ -80,6 +80,8 @@ class ProcessWrapper(CommonProcessWrapper):
 		CommonProcessWrapper.__init__(self, command, arguments, environs, workingDir, 
 			state, timeout, stdout, stderr, displayName, **kwargs)
 
+		assert self.environs, 'Cannot start a process with no environment variables set; use createEnvirons to make a minimal set of env vars'
+
 		# private instance variables
 		self.__hProcess = None
 		self.__hThread = None
@@ -155,7 +157,7 @@ class ProcessWrapper(CommonProcessWrapper):
 			old_command = command = self.__quotePath(self.command)
 			for arg in self.arguments: command = '%s %s' % (command, self.__quotePath(arg))
 			try:
-				self.__hProcess, self.__hThread, self.pid, self.__tid = win32process.CreateProcess( None, command, None, None, 1, 0, self.environs or None, os.path.normpath(self.workingDir), StartupInfo)
+				self.__hProcess, self.__hThread, self.pid, self.__tid = win32process.CreateProcess( None, command, None, None, 1, 0, self.environs, os.path.normpath(self.workingDir), StartupInfo)
 			except pywintypes.error as e:
 				raise ProcessError("Error creating process %s: %s" % (old_command, e))
 

--- a/pysys/process/user.py
+++ b/pysys/process/user.py
@@ -219,20 +219,20 @@ class ProcessUser(object):
 		Some features of this method can be configured by setting project 
 		properties:
 		
-		- `defaultEnvironsDefaultLang`: if set to a value such as `en_US.UTF-8` 
-		  the specified value is set for the LANG= variable on Unix; otherwise, 
-		  the LANG variable is not set (which might result in use of the 
-		  legacy POSIX/C encoding).
+		  - `defaultEnvironsDefaultLang`: if set to a value such as `en_US.UTF-8` 
+		    the specified value is set for the LANG= variable on Unix; otherwise, 
+		    the LANG variable is not set (which might result in use of the 
+		    legacy POSIX/C encoding).
 		  
-		- `defaultEnvironsTempDir`: if set the expression will be passed to 
-		  Python `eval()` and used to set the OS-specific temp directory 
-		  environment variables. A typical value is `self.output`.
+		  - `defaultEnvironsTempDir`: if set the expression will be passed to 
+		    Python `eval()` and used to set the OS-specific temp directory 
+		    environment variables. A typical value is `self.output`.
 		
-		- `defaultEnvironsLegacyMode`: set to true to enable compatibility 
-		  mode which keep the behaviour the same as PySys v1.1, 1.2 and 1.3, 
-		  namely using a completely empty default environment on Unix, and 
-		  a copy of the entire parent environment on Windows. This is not 
-		  recommended. 
+		  - `defaultEnvironsLegacyMode`: set to true to enable compatibility 
+		    mode which keep the behaviour the same as PySys v1.1, 1.2 and 1.3, 
+		    namely using a completely empty default environment on Unix, and 
+		    a copy of the entire parent environment on Windows. This is not 
+		    recommended. 
 
 		@param command: If known, the full path of the executable for which 
 		a default environment is being created (when called from `startProcess` 

--- a/pysys/process/user.py
+++ b/pysys/process/user.py
@@ -229,10 +229,12 @@ class ProcessUser(object):
 		    environment variables. A typical value is `self.output`.
 		
 		  - `defaultEnvironsLegacyMode`: set to true to enable compatibility 
-		    mode which keep the behaviour the same as PySys v1.1, 1.2 and 1.3, 
+		    mode which keeps the behaviour the same as PySys v1.1, 1.2 and 1.3, 
 		    namely using a completely empty default environment on Unix, and 
 		    a copy of the entire parent environment on Windows. This is not 
-		    recommended. 
+		    recommended unless you have a lot of legacy tests that cannot 
+		    easily be changed to only set minimal required environment 
+		    variables using `createEnvirons()`. 
 
 		@param command: If known, the full path of the executable for which 
 		a default environment is being created (when called from `startProcess` 

--- a/pysys/process/user.py
+++ b/pysys/process/user.py
@@ -289,8 +289,10 @@ class ProcessUser(object):
 		if command == sys.executable:
 			# ensure it's possible to run another instance of this Python
 			# (but only if full path exactly matches)
+			# keep it as clean as possible by not passing sys.path/PYTHONPATH
 			e['PATH'] = os.path.dirname(sys.executable)+os.pathsep+e['PATH']
 			e[LIBRARY_PATH_ENV_VAR] = os.getenv(LIBRARY_PATH_ENV_VAR,'')+os.pathsep+e[LIBRARY_PATH_ENV_VAR]
+			e['PYTHONHOME'] = sys.prefix
 		
 		return e
 

--- a/pysys/process/user.py
+++ b/pysys/process/user.py
@@ -219,20 +219,20 @@ class ProcessUser(object):
 		Some features of this method can be configured by setting project 
 		properties:
 		
-		  - `defaultEnvironsDefaultLang`: if set to a value such as 'en_US.UTF-8' 
-  		  the specified value is set for the LANG= variable on Unix; otherwise, 
-	  	  the LANG variable is not set (which might result in use of the 
-		    legacy POSIX/C encoding).
+		- `defaultEnvironsDefaultLang`: if set to a value such as `en_US.UTF-8` 
+		  the specified value is set for the LANG= variable on Unix; otherwise, 
+		  the LANG variable is not set (which might result in use of the 
+		  legacy POSIX/C encoding).
 		  
-		  - `defaultEnvironsTempDir`: if set the expression will be passed to 
-  		  Python `eval()` and used to set the OS-specific temp directory 
-	  	  environment variables. A typical value is `self.output`.
-	  	
-		  - `defaultEnvironsLegacyMode`: set to true to enable compatibility 
-		    mode which keep the behaviour the same as PySys v1.1, 1.2 and 1.3, 
-  		  namely using a completely empty default environment on Unix, and 
-	  	  a copy of the entire parent environment on Windows. This is not 
-		    recommended. 
+		- `defaultEnvironsTempDir`: if set the expression will be passed to 
+		  Python `eval()` and used to set the OS-specific temp directory 
+		  environment variables. A typical value is `self.output`.
+		
+		- `defaultEnvironsLegacyMode`: set to true to enable compatibility 
+		  mode which keep the behaviour the same as PySys v1.1, 1.2 and 1.3, 
+		  namely using a completely empty default environment on Unix, and 
+		  a copy of the entire parent environment on Windows. This is not 
+		  recommended. 
 
 		@param command: If known, the full path of the executable for which 
 		a default environment is being created (when called from `startProcess` 

--- a/pysys/process/user.py
+++ b/pysys/process/user.py
@@ -588,6 +588,13 @@ class ProcessUser(object):
 			outcomeReason = ''
 		else: 
 			outcomeReason = outcomeReason.strip().replace(u'\t', u' ')
+			if PY2 and isinstance(outcomeReason, str): 
+				# The python2 logger is very unhappy about byte str objects containing 
+				# non-ascii characters (specifically it will fail to log them and dump a 
+				# traceback on stderr). Since it's pretty important that assertion 
+				# messages and test outcome reasons don't get swallowed, add a 
+				# workaround for this here. Not a problem in python 3. 
+				outcomeReason = outcomeReason.decode('ascii', errors='replace')
 		
 		old = self.getOutcome()
 		self.outcome.append(outcome)
@@ -604,10 +611,10 @@ class ProcessUser(object):
 		if outcomeReason and printReason:
 			if outcome in FAILS:
 				if callRecord==None: callRecord = self.__callRecord()
-				log.warn('%s ... %s %s', outcomeReason, LOOKUP[outcome].lower(), '[%s]'%','.join(callRecord) if callRecord!=None else '',
+				log.warn(u'%s ... %s %s', outcomeReason, LOOKUP[outcome].lower(), u'[%s]'%','.join(callRecord) if callRecord!=None else u'',
 						 extra=BaseLogFormatter.tag(LOOKUP[outcome].lower(),1))
 			else:
-				log.info('%s ... %s', outcomeReason, LOOKUP[outcome].lower(), extra=BaseLogFormatter.tag(LOOKUP[outcome].lower(),1))
+				log.info(u'%s ... %s', outcomeReason, LOOKUP[outcome].lower(), extra=BaseLogFormatter.tag(LOOKUP[outcome].lower(),1))
 
 
 	def abort(self, outcome, outcomeReason, callRecord=None):

--- a/pysys/process/user.py
+++ b/pysys/process/user.py
@@ -546,7 +546,7 @@ class ProcessUser(object):
 			log.debug('ProcessUser cleanup function done.')
 		
 
-	def addOutcome(self, outcome, outcomeReason='', printReason=True, abortOnError=None, callRecord=None):
+	def addOutcome(self, outcome, outcomeReason='', printReason=True, abortOnError=False, callRecord=None):
 		"""Add a validation outcome (and optionally a reason string) to the validation list.
 		
 		The method provides the ability to add a validation outcome to the internal data structure 
@@ -575,8 +575,9 @@ class ProcessUser(object):
 		
 		@param printReason: If True the specified outcomeReason will be printed
 		
-		@param abortOnError: If true abort the test on any error outcome (defaults to the defaultAbortOnError
-		project setting if not specified)
+		@param abortOnError: If true abort the test on any error outcome. This should usually be set to 
+		False for assertions, or the configured `self.defaultAbortOnError` setting (typically True) for 
+		operations that involve waiting. 
 		
 		@param callRecord: An array of strings indicating the call stack that lead to this outcome. This will be appended
 		to the log output for better test triage.

--- a/pysys/process/user.py
+++ b/pysys/process/user.py
@@ -219,18 +219,20 @@ class ProcessUser(object):
 		Some features of this method can be configured by setting project 
 		properties:
 		
-		- `defaultEnvironsDefaultLang`: if set to a value such as 'en_US.UTF-8' 
-		  the specified value is set for the LANG= variable on Unix; otherwise, 
-		  the LANG variable is not set (which might result in use of the 
-		  legacy POSIX/C encoding).
-		- `defaultEnvironsTempDir`: if set the expression will be passed to 
-		  Python `eval()` and used to set the OS-specific temp directory 
-		  environment variables. A typical value is `self.output`.
-		- `defaultEnvironsLegacyMode`: set to true to enable compatibility 
-		  mode which keep the behaviour the same as PySys v1.1, 1.2 and 1.3, 
-		  namely using a completely empty default environment on Unix, and 
-		  a copy of the entire parent environment on Windows. This is not 
-		  recommended. 
+		  - `defaultEnvironsDefaultLang`: if set to a value such as 'en_US.UTF-8' 
+  		  the specified value is set for the LANG= variable on Unix; otherwise, 
+	  	  the LANG variable is not set (which might result in use of the 
+		    legacy POSIX/C encoding).
+		  
+		  - `defaultEnvironsTempDir`: if set the expression will be passed to 
+  		  Python `eval()` and used to set the OS-specific temp directory 
+	  	  environment variables. A typical value is `self.output`.
+	  	
+		  - `defaultEnvironsLegacyMode`: set to true to enable compatibility 
+		    mode which keep the behaviour the same as PySys v1.1, 1.2 and 1.3, 
+  		  namely using a completely empty default environment on Unix, and 
+	  	  a copy of the entire parent environment on Windows. This is not 
+		    recommended. 
 
 		@param command: If known, the full path of the executable for which 
 		a default environment is being created (when called from `startProcess` 

--- a/pysys/process/user.py
+++ b/pysys/process/user.py
@@ -28,6 +28,7 @@ from pysys.process.helper import ProcessWrapper
 from pysys.utils.allocport import TCPPortOwner
 from pysys.utils.fileutils import mkdir
 from pysys.utils.pycompat import *
+from pysys.utils.stringutils import compareVersions
 
 STDOUTERR_TUPLE = collections.namedtuple('stdouterr', ['stdout', 'stderr'])
 
@@ -871,3 +872,65 @@ class ProcessUser(object):
 				return e['encoding']
 		return None
 	
+	@staticmethod
+	def compareVersions(v1, v2):
+		""" Compares two alphanumeric dotted version strings to see which is more recent. 
+		
+		Example usage::
+		
+			if self.compareVersions(thisversion, '1.2.alpha-3') > 0:
+				... # thisversion is newer than 1.2.alpha-3 
+
+		The comparison algorithm ignores case, and normalizes separators ./-/_ 
+		so that `'1.alpha2'=='1Alpha2'`. Any string components are compared 
+		lexicographically with other strings, and compared to numbers 
+		strings are always considered greater. 
+
+		@param v1: A string containing a version number, with any number of components. 
+		@param v2: A string containing a version number, with any number of components. 
+
+		@return: an integer > 0 if v1>v2, 
+		an integer < 0 if v1<v2, 
+		or 0 if they are semantically the same.
+		
+		>>> ProcessUser.compareVersions('10-alpha5.dev10', '10alpha-5-dEv_10') == 0 # normalization of case and separators
+		True
+
+		>>> ProcessUser.compareVersions(b'1....alpha.2', u'1Alpha2') == 0 # ascii byte and unicode strings both supported
+		True
+
+		>>> ProcessUser.compareVersions('1.2.0', '1.2')
+		0
+
+		>>> ProcessUser.compareVersions('1.02', '1.2')
+		0
+
+		>>> ProcessUser().compareVersions('1.2.3', '1.2') > 0
+		True
+
+		>>> ProcessUser.compareVersions('1.2', '1.2.3')
+		-1
+		
+		>>> ProcessUser.compareVersions('10.2', '1.2')
+		1
+
+		>>> ProcessUser.compareVersions('1.2.text', '1.2.0') # letters are > numbers
+		1
+
+		>>> ProcessUser.compareVersions('1.2.text', '1.2') # letters are > numbers 
+		1
+
+		>>> ProcessUser.compareVersions('10.2alpha1', '10.2alpha')
+		1
+
+		>>> ProcessUser.compareVersions('10.2dev', '10.2alpha') # letters are compared lexicographically
+		1
+
+		>>> ProcessUser.compareVersions('', '')
+		0
+
+		>>> ProcessUser.compareVersions('1', '')
+		1
+
+		"""
+		return compareVersions(v1, v2)

--- a/pysys/process/user.py
+++ b/pysys/process/user.py
@@ -284,7 +284,7 @@ class ProcessUser(object):
 				
 		if not IS_WINDOWS:
 			if getattr(PROJECT, 'defaultEnvironsDefaultLang',''):
-				e['LANG'] = PROJECT.cleanEnvironsDefaultLang
+				e['LANG'] = PROJECT.defaultEnvironsDefaultLang
 		
 		if command == sys.executable:
 			# ensure it's possible to run another instance of this Python

--- a/pysys/utils/fileutils.py
+++ b/pysys/utils/fileutils.py
@@ -28,9 +28,9 @@ def mkdir(path):
 	"""
 	try:
 		os.makedirs(path)
-	except OSError as e:
+	except Exception as e:
 		if not os.path.isdir(path):
-			raise e
+			raise
 
 def deletedir(path):
 	"""

--- a/pysys/utils/stringutils.py
+++ b/pysys/utils/stringutils.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+# PySys System Test Framework, Copyright (C) 2006-2019 M.B. Grieve
+
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+
+from pysys.constants import *
+from pysys.utils.pycompat import *
+
+"""
+Utility methods involving string manipulation. 
+"""
+
+__all__ = [
+	'compareVersions',
+]
+
+def compareVersions(v1, v2):
+	""" Compares two alphanumeric dotted version strings to see which is more recent. 
+	
+	See L{ProcessUser.compareVersions} for more details. 
+	"""
+	
+	def normversion(v):
+		# convert from bytes to strings if necessary
+		if isinstance(v, binary_type): v = v.decode('utf-8')
+		
+		# normalize versions into a list of components, with integers for the numeric bits
+		v = [int(x) if x.isdigit() else x for x in re.split(u'([0-9]+|[.])', v.lower().replace('-','.').replace('_','.')) if (x and x != u'.') ]
+		
+		return v
+	
+	v1 = normversion(v1)
+	v2 = normversion(v2)
+	
+	# make them the same length
+	while len(v1)<len(v2): v1.append(0)
+	while len(v1)>len(v2): v2.append(0)
+
+	for i in range(len(v1)):
+		if type(v1[i]) != type(v2[i]): # can't use > on different types
+			if type(v2[i])==int: # define string>int
+				return +1
+			else:
+				return -1
+		else:
+			if v1[i] > v2[i]: return 1
+			if v1[i] < v2[i]: return -1
+	return 0

--- a/pysys/utils/stringutils.py
+++ b/pysys/utils/stringutils.py
@@ -30,7 +30,7 @@ __all__ = [
 def compareVersions(v1, v2):
 	""" Compares two alphanumeric dotted version strings to see which is more recent. 
 	
-	See L{ProcessUser.compareVersions} for more details. 
+	See L{pysys.process.user.ProcessUser.compareVersions} for more details. 
 	"""
 	
 	def normversion(v):

--- a/pysys/xml/project.py
+++ b/pysys/xml/project.py
@@ -23,6 +23,7 @@ from pysys.constants import *
 from pysys import __version__
 from pysys.utils.loader import import_module
 from pysys.utils.logutils import ColorLogFormatter, BaseLogFormatter
+from pysys.utils.stringutils import compareVersions
 log = logging.getLogger('pysys.xml.project')
 
 DTD='''
@@ -110,15 +111,7 @@ class XMLProjectParser(object):
 			requirespysys = requirespysys[0].firstChild.nodeValue
 			if requirespysys:
 				thisversion = __version__
-				
-				def compareVersions(v1, v2):
-					v1 = [int(i) if i.isdigit() else i for i in v1.split('.')]
-					v2 = [int(i) if i.isdigit() else i for i in v2.split('.')]
-					if v1 > v2: return 1
-					if v1 == v2: return 0
-					return -1
-				
-				if compareVersions(thisversion, requirespysys) < 0:
+				if compareVersions(requirespysys, thisversion) > 0:
 					raise Exception('This test project requires PySys version %s or greater, but this is version %s'%(requirespysys, thisversion))
 
 


### PR DESCRIPTION
Fixed serious bug GH-9 in PySys v1.1/1.2/1.3 in which startProcess would use a completely empty environment on unix but inherit all env vars from parent process on Windows (due to self.environs **or None** in plat-win32/helper) if environs= was empty/None/unspecified; since the fix is a change of behaviour there's a project setting to disable it and use legacy mode if needed. Using a clean environment is important for reliable testing that a) gives information about the application under test without unwanted/expected influence from user's environment and b) ensures tests behave the same way for all users - hence I felt it was worth fixing this despite it potentially changing behaviour for existing tests. 
   As part of this, added getDefaultEnvirons() and createEnvirons() to make it easy for test authors to create a suitable clean environment, and provide platform-specific or command-specific customizations. getDefaultEnvirons() automatically adds required env vars to allow correct execution of the current Python interpreter. New project options allow XML configuration of default temp dir and LANG (both now in sample pysysproject.xml). 

Improved usability of abortOnError by having it only affect operations that wait (e.g. waitForSignal/startProcess etc) and not assertions which gives nice fail-fast behaviour without needlessly throwing away useful diagnostic information (this was really bugging people who like to  use defaultAbortOnError in their projects, since they were having to explicitly set abortOnError=False in assertions all over the place to get the desired behaviour). Also removed `**xargs` pattern in assert methods which was causing users to not notice when they had a typo in their keyword args (would be silently ignored) and not adding value compared to the normal parameter passing mechanism. 

Added useful pythonDocTest and compareVersions methods. compareVersions is a static on ProcessUser since being able to invoke utiltiy methods with self.* is very handy; annoyingly I had to put the actual implementation into a separate module (stringutils) purely so it could be executed during project parsing without introducing circular dependency problems. 

(Plus a minor enhancement to consistently set self.stdout/err on process wrapper baseclass for both platforms (rather than using fStdout/err on one of them) which removes the need for someone starting a process to stash the stdout/err paths themselves before calling startProcess.)