### PR TITLE
startBackgroundThread

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -131,6 +131,17 @@ New features
   the ability to write directly to stdout should be changed to use 
   `pysys.utils.logutils.stdoutPrint`. 
 
+- Added `BaseTest.startBackgroundThread` method which takes care of ensuring 
+  threads are stopped and joined during cleanup, that exceptions from threads 
+  result in BLOCKED outcomes and that logging output from background threads 
+  goes to the same handlers as foreground logging. The thread target can 
+  be either a simple function or an instance method (e.g. on the testcase). 
+  A Python `threading.Event` object called `stopped` is passed to the 
+  background thread to make it easy to determine when it should finish 
+  executing. Added documentation comments to make clear most of 
+  `BaseTest`/`ProcessUser` are still not thread-safe, but the all-important 
+  `addOutcome` method now is. 
+
 - Added new command line option `--printLogs all|failures|none` (default value 
   is `all`) which allows user to avoid the printing of run.log to the stdout 
   console either for all tests, or for tests that pass. This is useful to 

--- a/pysys-examples/internal/testcases/PySys_internal_086/Input/mypkg/customfmt.py
+++ b/pysys-examples/internal/testcases/PySys_internal_086/Input/mypkg/customfmt.py
@@ -12,8 +12,8 @@ if os.getenv('LANG','') and 'win' in sys.platform:
 	locale.getpreferredencoding = customized_getpreferredencoding 
 	sys.stdout.write('HACKED preferred encoding to: %s\n'%locale.getpreferredencoding())
 	
-	# if coloring is not enable we need to explicitly recreate the stream wrapper with the new encoding
-	stdoutHandler._updateUnderlyingStream()
+	# in case coloring is not enabled we need this to explicitly re-execute the logic in _UnicodeSafeStreamWrapper that decides the encoding
+	stdoutHandler.stream.updateUnderlyingStream(stdoutHandler.stream.stream)
 
 class CustomFormatter(ColorLogFormatter):
 	pass

--- a/pysys-examples/internal/testcases/PySys_internal_098/Input/JoinCleanupException/pysystest.xml
+++ b/pysys-examples/internal/testcases/PySys_internal_098/Input/JoinCleanupException/pysystest.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" standalone="yes"?>
+<pysystest type="auto" state="runnable">
+    
+  <description> 
+    <title>Nested testcase</title>    
+    <purpose><![CDATA[
+
+]]>
+    </purpose>
+  </description>
+
+  <classification>
+    <groups>
+    </groups>
+  </classification>
+
+  <data>
+    <class name="PySysTest" module="run"/>
+  </data>
+  
+</pysystest>

--- a/pysys-examples/internal/testcases/PySys_internal_098/Input/JoinCleanupException/run.py
+++ b/pysys-examples/internal/testcases/PySys_internal_098/Input/JoinCleanupException/run.py
@@ -1,0 +1,23 @@
+from pysys.constants import *
+from pysys.basetest import BaseTest
+from pysys.exceptions import *
+
+class PySysTest(BaseTest):
+	def execute(self):
+		def afunction(stopping, log, **kwargs):
+			log.info('Hello from function thread')
+			raise Exception('Simulated exception from background thread')
+		
+		f = self.startBackgroundThread('FunctionThread', afunction)
+		# make sure thread has failed before cleanup begins
+		for i in range(20):
+			if f.exception is not None: break
+			# don't use f.join() since to test this codepath we want to call f.join() only during cleanup
+			f.thread.join(1)
+		
+		f.thread.join(5)
+		
+		self.log.info('End of execute()')
+
+	def validate(self):
+		pass 

--- a/pysys-examples/internal/testcases/PySys_internal_098/Input/JoinCleanupTimeout/pysystest.xml
+++ b/pysys-examples/internal/testcases/PySys_internal_098/Input/JoinCleanupTimeout/pysystest.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" standalone="yes"?>
+<pysystest type="auto" state="runnable">
+    
+  <description> 
+    <title>Nested testcase</title>    
+    <purpose><![CDATA[
+
+]]>
+    </purpose>
+  </description>
+
+  <classification>
+    <groups>
+    </groups>
+  </classification>
+
+  <data>
+    <class name="PySysTest" module="run"/>
+  </data>
+  
+</pysystest>

--- a/pysys-examples/internal/testcases/PySys_internal_098/Input/JoinCleanupTimeout/run.py
+++ b/pysys-examples/internal/testcases/PySys_internal_098/Input/JoinCleanupTimeout/run.py
@@ -8,8 +8,10 @@ class PySysTest(BaseTest):
 			log.info('Hello from function thread')
 			stopping.wait(60*10) # this will block until cleanup
 			stopping.clear()
-			log.info('Background thread got request to stop but wont do it just yet')
-			stopping.wait(15) # this will cause it to timeout after cleanup
+			def functionThatAppearsToHang():
+				log.info('Background thread got request to stop but wont do it just yet')
+				stopping.wait(15) # this will cause it to timeout after cleanup
+			functionThatAppearsToHang()
 					
 		f = self.startBackgroundThread('FunctionThread', afunction)
 		assert f.joinTimeoutSecs > 0

--- a/pysys-examples/internal/testcases/PySys_internal_098/Input/JoinCleanupTimeout/run.py
+++ b/pysys-examples/internal/testcases/PySys_internal_098/Input/JoinCleanupTimeout/run.py
@@ -1,0 +1,21 @@
+from pysys.constants import *
+from pysys.basetest import BaseTest
+from pysys.exceptions import *
+
+class PySysTest(BaseTest):
+	def execute(self):
+		def afunction(stopping, log, **kwargs):
+			log.info('Hello from function thread')
+			stopping.wait(60*10) # this will block until cleanup
+			stopping.clear()
+			log.info('Background thread got request to stop but wont do it just yet')
+			stopping.wait(15) # this will cause it to timeout after cleanup
+					
+		f = self.startBackgroundThread('FunctionThread', afunction)
+		assert f.joinTimeoutSecs > 0
+		f.joinTimeoutSecs = 2 # don't waste a long time waiting
+		
+		self.log.info('End of execute()')
+
+	def validate(self):
+		pass 

--- a/pysys-examples/internal/testcases/PySys_internal_098/Input/JoinExecuteException/pysystest.xml
+++ b/pysys-examples/internal/testcases/PySys_internal_098/Input/JoinExecuteException/pysystest.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" standalone="yes"?>
+<pysystest type="auto" state="runnable">
+    
+  <description> 
+    <title>Nested testcase</title>    
+    <purpose><![CDATA[
+
+]]>
+    </purpose>
+  </description>
+
+  <classification>
+    <groups>
+    </groups>
+  </classification>
+
+  <data>
+    <class name="PySysTest" module="run"/>
+  </data>
+  
+</pysystest>

--- a/pysys-examples/internal/testcases/PySys_internal_098/Input/JoinExecuteException/run.py
+++ b/pysys-examples/internal/testcases/PySys_internal_098/Input/JoinExecuteException/run.py
@@ -1,0 +1,17 @@
+from pysys.constants import *
+from pysys.basetest import BaseTest
+from pysys.exceptions import *
+
+class PySysTest(BaseTest):
+	def execute(self):
+		def afunction(stopping, log, **kwargs):
+			log.info('Hello from function thread')
+			raise Exception('Simulated exception from background thread')
+		
+		f = self.startBackgroundThread('FunctionThread', afunction)
+		f.join(timeout=30, abortOnError=True) # should detect the exception
+		
+		self.log.info('End of execute()') # should not get here
+
+	def validate(self):
+		pass 

--- a/pysys-examples/internal/testcases/PySys_internal_098/Input/JoinExecuteTimeout/pysystest.xml
+++ b/pysys-examples/internal/testcases/PySys_internal_098/Input/JoinExecuteTimeout/pysystest.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" standalone="yes"?>
+<pysystest type="auto" state="runnable">
+    
+  <description> 
+    <title>Nested testcase</title>    
+    <purpose><![CDATA[
+
+]]>
+    </purpose>
+  </description>
+
+  <classification>
+    <groups>
+    </groups>
+  </classification>
+
+  <data>
+    <class name="PySysTest" module="run"/>
+  </data>
+  
+</pysystest>

--- a/pysys-examples/internal/testcases/PySys_internal_098/Input/JoinExecuteTimeout/run.py
+++ b/pysys-examples/internal/testcases/PySys_internal_098/Input/JoinExecuteTimeout/run.py
@@ -5,7 +5,7 @@ from pysys.exceptions import *
 class PySysTest(BaseTest):
 	def execute(self):
 		def afunction(stopping, log, **kwargs):
-			log.info('Hello from function thread')
+			log.info('Hello from function thread')			
 			while not stopping.is_set():
 				stopping.wait(1.0)
 		

--- a/pysys-examples/internal/testcases/PySys_internal_098/Input/JoinExecuteTimeout/run.py
+++ b/pysys-examples/internal/testcases/PySys_internal_098/Input/JoinExecuteTimeout/run.py
@@ -1,0 +1,21 @@
+from pysys.constants import *
+from pysys.basetest import BaseTest
+from pysys.exceptions import *
+
+class PySysTest(BaseTest):
+	def execute(self):
+		def afunction(stopping, log, **kwargs):
+			log.info('Hello from function thread')
+			while not stopping.is_set():
+				stopping.wait(1.0)
+		
+		f = self.startBackgroundThread('FunctionThread', afunction)
+		f.join(1) # will fail cos we didn't ask it to stop. but it should now be asked to terminate
+		
+		f.join(timeout=30, abortOnError=True) # should succeed since the above will have implicitly cancelled it
+		self.assertTrue(not f.isAlive(), assertMessage='MethodThread is no longer alive')
+		
+		self.log.info('End of execute()')
+
+	def validate(self):
+		pass 

--- a/pysys-examples/internal/testcases/PySys_internal_098/Input/Success/pysystest.xml
+++ b/pysys-examples/internal/testcases/PySys_internal_098/Input/Success/pysystest.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" standalone="yes"?>
+<pysystest type="auto" state="runnable">
+    
+  <description> 
+    <title>Nested testcase</title>    
+    <purpose><![CDATA[
+
+]]>
+    </purpose>
+  </description>
+
+  <classification>
+    <groups>
+      <group>outcomes</group>
+    </groups>
+  </classification>
+
+  <data>
+    <class name="PySysTest" module="run"/>
+  </data>
+  
+  <traceability>
+    <requirements>
+      <requirement id=""/>     
+    </requirements>
+  </traceability>
+</pysystest>

--- a/pysys-examples/internal/testcases/PySys_internal_098/Input/Success/run.py
+++ b/pysys-examples/internal/testcases/PySys_internal_098/Input/Success/run.py
@@ -1,0 +1,32 @@
+from pysys.constants import *
+from pysys.basetest import BaseTest
+from pysys.exceptions import *
+
+class PySysTest(BaseTest):
+	def execute(self):
+		def afunction(stopping, log):
+			log.info('Hello from function thread')
+		
+		f = self.startBackgroundThread('FunctionThread', afunction)
+		
+		m = self.startBackgroundThread('MethodThread', target=self.instancemethod, kwargsForTarget={'param': 123})
+		self.assertTrue(m.is_alive(), assertMessage='MethodThread is initially alive')
+
+		m.stop()
+
+		m.join(timeout=30, abortOnError=True) # should succeed since the above will have implicitly cancelled it
+		self.assertTrue(not m.isAlive(), assertMessage='MethodThread is no longer alive')
+		self.assertTrue(m.exception is None, assertMessage='MethodThread .exception was not set since it occurred during thread stopping')
+		
+		self.log.info('End of execute()')
+
+	def validate(self):
+		pass 
+
+	def instancemethod(self, param, log, stopping):
+		log.info('Hello from instance method thread: param=%d', param)
+		while not stopping.is_set():
+			stopping.wait(10*60)
+		# these exceptions don't cause test failures
+		raise Exception('Simulated error after instance method thread was asked to stop')
+		

--- a/pysys-examples/internal/testcases/PySys_internal_098/Input/pysysproject.xml
+++ b/pysys-examples/internal/testcases/PySys_internal_098/Input/pysysproject.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" standalone="yes"?>
+<pysysproject>
+	<property environment="env"/>
+
+	<property osfamily="osfamily"/>
+
+	<property name="defaultAbortOnError" value="true"/>
+	
+</pysysproject>

--- a/pysys-examples/internal/testcases/PySys_internal_098/pysystest.xml
+++ b/pysys-examples/internal/testcases/PySys_internal_098/pysystest.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" standalone="yes"?>
+<pysystest type="auto" state="runnable">
+    
+  <description> 
+    <title>BaseTest - startBackgroundThread</title>    
+    <purpose><![CDATA[
+Check background thread handling. 
+]]>
+    </purpose>
+  </description>
+
+  <classification>
+    <groups>
+      <group>basetest</group>
+    </groups>
+  </classification>
+
+  <data>
+    <class name="PySysTest" module="run"/>
+  </data>
+  
+  <traceability>
+    <requirements>
+      <requirement id=""/>     
+    </requirements>
+  </traceability>
+</pysystest>

--- a/pysys-examples/internal/testcases/PySys_internal_098/run.py
+++ b/pysys-examples/internal/testcases/PySys_internal_098/run.py
@@ -1,0 +1,73 @@
+import os, sys, math, shutil
+from pysys.constants import *
+from pysys.basetest import BaseTest
+
+class PySysTest(BaseTest):
+
+	def execute(self):
+		l = {}
+		exec(open(os.path.normpath(self.input+'/../../../utilities/resources/runpysys.py')).read(), {}, l) # define runPySys
+		runPySys = l['runPySys']
+		
+		shutil.copytree(self.input, self.output+'/test')
+		runPySys(self, 'pysys', ['run', '-o', self.output+'/pysys-output', '-v', 'debug'], workingDir='test', ignoreExitStatus=True)
+		self.logFileContents('pysys.out', maxLines=0)
+
+		# quick interactive demo of success
+		def mythreadtarget(log, stopping):
+			log.info('Hello from thread!')
+			while not stopping.is_set():
+				if not stopping.wait(1): return
+		t = self.startBackgroundThread('MyBackgroundThread', mythreadtarget)
+		t.stop().join()
+			
+	def validate(self):
+	
+		# ensure output from thread makes it into both stdout and run.log
+		for f in ['pysys-output/Success/run.log', 'pysys.out']:
+			self.assertGrep(f, expr=r'DEBUG .*\[Success.FunctionThread\] starting')
+			self.assertGrep(f, expr=r'DEBUG .*\[Success.FunctionThread\] completed successfully')
+
+			self.assertGrep(f, expr=r'INFO .*Hello from function thread')
+			# checks parameter passing
+			self.assertGrep(f, expr=r'INFO .*Hello from instance method thread: param=123')
+	
+		self.assertOrderedGrep('pysys-output/Success/run.log', exprList=[
+		'End of execute',
+		'Joining background thread .*FunctionThread',
+		'cleanup function done',
+		])
+		self.assertGrep('pysys-output/Success/run.log', expr=r'Test final outcome:.*PASSED')
+		self.log.info('')
+		
+		self.assertGrep('pysys-output/JoinCleanupException/run.log', expr=r'ERROR .*JoinCleanupException.FunctionThread\] Background thread failed')
+		self.assertOrderedGrep('pysys-output/JoinCleanupException/run.log', exprList=[
+			r'Traceback \(most recent call last\)', 
+			r'Exception: Simulated exception from background thread',
+			r'End of execute',
+			])
+		self.assertGrep('pysys-output/JoinCleanupException/run.log', expr=r'Test final outcome:.*BLOCKED')
+		self.assertGrep('pysys-output/JoinCleanupException/run.log', expr=r'Test failure reason:.*Background thread JoinCleanupException.FunctionThread failed with Exception: Simulated exception from background thread')
+		self.log.info('')
+		
+		self.assertOrderedGrep('pysys-output/JoinExecuteException/run.log', exprList=[
+			r'ERROR .*JoinExecuteException.FunctionThread\] Background thread failed',
+			r'Traceback \(most recent call last\)', 
+			r'Exception: Simulated exception from background thread',
+			])
+		self.assertGrep('pysys-output/JoinExecuteException/run.log', expr=r'End of execute', contains=False) # since we aborted on error
+
+		self.assertGrep('pysys-output/JoinExecuteException/run.log', expr=r'Test final outcome:.*BLOCKED')
+		self.assertGrep('pysys-output/JoinExecuteException/run.log', expr=r'Test failure reason:.*Background thread JoinExecuteException.FunctionThread failed with Exception: Simulated exception from background thread')
+		self.log.info('')
+
+
+		self.assertOrderedGrep('pysys-output/JoinExecuteTimeout/run.log', exprList=[
+			r'INFO .*Joining background thread .*FunctionThread',
+			r'WARN .*Background thread JoinExecuteTimeout.FunctionThread is still running after waiting for allocated timeout period \(\d secs\) ... .*timed out',
+			r'End of execute', 
+			])
+		self.assertGrep('pysys-output/JoinExecuteTimeout/run.log', expr=r'Test final outcome:.*TIMED OUT')
+		self.assertGrep('pysys-output/JoinExecuteTimeout/run.log', expr=r'Test failure reason:.*Background thread JoinExecuteTimeout.FunctionThread is still running after waiting for allocated timeout period')
+		self.log.info('')
+

--- a/pysys/baserunner.py
+++ b/pysys/baserunner.py
@@ -690,7 +690,9 @@ class TestContainer(object):
 					try:
 						if not self.runner.validateOnly:
 							self.testObj.setup()
+							log.debug('--- test execute')
 							self.testObj.execute()
+						log.debug('--- test validate')
 						self.testObj.validate()
 					except AbortExecution as e:
 						del self.testObj.outcome[:]
@@ -710,6 +712,7 @@ class TestContainer(object):
 		
 			# call the cleanup method to tear down the test
 			try:
+				log.debug('--- test cleanup')
 				self.testObj.cleanup()
 			
 			except KeyboardInterrupt:

--- a/pysys/baserunner.py
+++ b/pysys/baserunner.py
@@ -43,7 +43,7 @@ from pysys.basetest import BaseTest
 from pysys.process.user import ProcessUser
 from pysys.utils.logutils import BaseLogFormatter
 from pysys.utils.pycompat import *
-from pysys.internal.initlogging import _UnicodeSafeStreamWrapper, ThreadFilter
+from pysys.internal.initlogging import _UnicodeSafeStreamWrapper, pysysLogHandler
 from pysys.writer import ConsoleSummaryResultsWriter, ConsoleProgressResultsWriter, BaseSummaryResultsWriter, BaseProgressResultsWriter
 
 global_lock = threading.Lock()
@@ -164,38 +164,6 @@ class BaseRunner(ProcessUser):
 		
 		self.performanceReporters = [] # gets assigned to real value by start(), once runner constructors have all completed
 		
-		class DelegatingPerThreadLogHandler(logging.Handler):
-			"""A log handler that delegates emits to a list of handlers, 
-			set on a per-thread basis. If no handlers are setup for this 
-			thread nothing is emitted.
-			
-			Note that calling close() on this handler does not call close 
-			on any of the delegated handlers (since they may 
-			be used by multiple threads, and to avoid leaks we don't keep a 
-			global list of them anyway). 
-			"""
-			def __init__(self):
-				super(DelegatingPerThreadLogHandler, self).__init__()
-				self.__threadLocals = threading.local()
-
-			def setLogHandlersForCurrentThread(self, handlers):
-				self.__threadLocals.handlers = handlers
-				self.__threadLocals.emitFunctions = [(h.level, h.emit) for h in handlers] if handlers else None
-			def getLogHandlersForCurrentThread(self):
-				return getattr(self.__threadLocals, 'handlers', None) or []
-			
-			def emit(self, record):
-				functions = getattr(self.__threadLocals, 'emitFunctions', None) 
-				if functions is not None: 
-					for (hdlrlevel, emitFunction) in functions:
-						# handlers can have different levels, so need to replicate the checking that callHandlers performs
-						if record.levelno >= hdlrlevel:
-							emitFunction(record)
-			def flush(self): 
-				for h in self.getLogHandlersForCurrentThread(): h.flush()
-		
-		self._testThreadsLogHandler = DelegatingPerThreadLogHandler()
-
 	def __str__(self): 
 		""" Returns a human-readable and unique string representation of this runner object containing the runner class, 
 		suitable for diagnostic purposes and display to the test author. 
@@ -326,7 +294,6 @@ class BaseRunner(ProcessUser):
 		results.
 
 		"""
-		log.addHandler(self._testThreadsLogHandler)
 		if PROJECT.perfReporterConfig:
 			# must construct perf reporters here in start(), since if we did it in baserunner constructor, runner 
 			# might not be fully constructed yet
@@ -384,10 +351,8 @@ class BaseRunner(ProcessUser):
 		try:
 
 			# for suppressing print-as-we-execute in single-threaded mode (at least until outcome is known)
-			if self.threads==1 and self.printLogs!=PrintLogs.ALL:
-				singleThreadStdoutDisable = ThreadFilter()
-			else:
-				singleThreadStdoutDisable = None
+			singleThreadStdoutDisable = self.threads==1 and self.printLogs!=PrintLogs.ALL
+			assert pysysLogHandler.getLogHandlersForCurrentThread()==[stdoutHandler] # the code below assumes this
 				
 			for cycle in range(self.cycle):
 				# loop through tests for the cycle
@@ -401,11 +366,11 @@ class BaseRunner(ProcessUser):
 							request = WorkRequest(container, callback=self.containerCallback, exc_callback=self.containerExceptionCallback)
 							threadPool.putRequest(request)
 						else:
-							if singleThreadStdoutDisable: stdoutHandler.addFilter(singleThreadStdoutDisable)
+							if singleThreadStdoutDisable: pysysLogHandler.setLogHandlersForCurrentThread([])
 							try:
 								singleThreadedResult = container() # run test
 							finally:
-								if singleThreadStdoutDisable: stdoutHandler.removeFilter(singleThreadStdoutDisable)
+								if singleThreadStdoutDisable: pysysLogHandler.setLogHandlersForCurrentThread([stdoutHandler])
 							self.containerCallback(threading.current_thread().ident, singleThreadedResult)
 				except KeyboardInterrupt:
 					log.info("test interrupt from keyboard")
@@ -619,156 +584,158 @@ class TestContainer(object):
 		exc_info = []
 		self.testStart = time.time()
 		
+		defaultLogHandlersForCurrentThread = pysysLogHandler.getLogHandlersForCurrentThread()
 		try:
-			# stdout - set this up right at the very beginning to ensure we can see the log output in case any later step fails
-			# here we use UnicodeSafeStreamWrapper to ensure we get a buffer of unicode characters (mixing chars+bytes leads to exceptions), 
-			# from any supported character (utf-8 being pretty much a superset of all encodings)
-			self.testFileHandlerStdout = logging.StreamHandler(_UnicodeSafeStreamWrapper(self.testFileHandlerStdoutBuffer, writebytes=False, encoding='utf-8'))
-			self.testFileHandlerStdout.setFormatter(PROJECT.formatters.stdout)
-			self.testFileHandlerStdout.setLevel(stdoutHandler.level)
-			self.runner._testThreadsLogHandler.setLogHandlersForCurrentThread([self.testFileHandlerStdout])
-
-			# set the output subdirectory and purge contents
-			if os.path.isabs(self.runner.outsubdir):
-				self.outsubdir = os.path.join(self.runner.outsubdir, self.descriptor.id)
-			else:
-				self.outsubdir = os.path.join(self.descriptor.output, self.runner.outsubdir)
-
-			if not self.runner.validateOnly: 
-				if self.runner.cycle <= 1: 
-					deletedir(self.outsubdir)
-				else:
-					# must use lock to avoid deleting the parent dir after we've started creating outdirs for some cycles
-					with global_lock:
-						if self.outsubdir not in TestContainer.__purgedOutputDirs:
-							deletedir(self.outsubdir)
-							TestContainer.__purgedOutputDirs.add(self.outsubdir)
-			
-			if self.runner.cycle > 1: 
-				self.outsubdir = os.path.join(self.outsubdir, 'cycle%d' % (self.cycle+1))
-			mkdir(self.outsubdir)
-
-			# run.log handler
-			runLogEncoding = self.runner.getDefaultFileEncoding('run.log') or locale.getpreferredencoding()
-			self.testFileHandlerRunLog = logging.StreamHandler(_UnicodeSafeStreamWrapper(
-				io.open(os.path.join(self.outsubdir, 'run.log'), 'a', encoding=runLogEncoding), 
-				writebytes=False, encoding=runLogEncoding))
-			self.testFileHandlerRunLog.setFormatter(PROJECT.formatters.runlog)
-			self.testFileHandlerRunLog.setLevel(logging.INFO)
-			if stdoutHandler.level == logging.DEBUG: self.testFileHandlerRunLog.setLevel(logging.DEBUG)
-			self.runner._testThreadsLogHandler.setLogHandlersForCurrentThread([self.testFileHandlerStdout, self.testFileHandlerRunLog])
-
-			log.info(62*"=")
-			title = textwrap.wrap(self.descriptor.title.replace('\n','').strip(), 56)
-			log.info("Id   : %s", self.descriptor.id, extra=BaseLogFormatter.tag(LOG_TEST_DETAILS, 0))
-			if len(title)>0:
-				log.info("Title: %s", str(title[0]), extra=BaseLogFormatter.tag(LOG_TEST_DETAILS, 0))
-			for l in title[1:]:
-				log.info("       %s", str(l), extra=BaseLogFormatter.tag(LOG_TEST_DETAILS, 0))
-			if self.runner.cycle > 1:
-				log.info("Cycle: %s", str(self.cycle+1), extra=BaseLogFormatter.tag(LOG_TEST_DETAILS, 0))
-			log.info(62*"=")
-		except KeyboardInterrupt:
-			self.kbrdInt = True
-		
-		except Exception:
-			exc_info.append(sys.exc_info())
-			
-		# import the test class
-		with global_lock:
-			BaseTest._currentTestCycle = (self.cycle+1) if (self.runner.cycle > 1) else 0 # backwards compatible way of passing cycle to BaseTest constructor; safe because of global_lock
 			try:
-				runpypath = self.descriptor.module+'.py'
-				with open(runpypath, 'rb') as runpyfile:
-					runpycode = compile(runpyfile.read(), runpypath, 'exec')
-				runpy_namespace = {}
-				exec(runpycode, runpy_namespace)
-				self.testObj = runpy_namespace[self.descriptor.classname](self.descriptor, self.outsubdir, self.runner)
-				del runpy_namespace
-	
+				# stdout - set this up right at the very beginning to ensure we can see the log output in case any later step fails
+				# here we use UnicodeSafeStreamWrapper to ensure we get a buffer of unicode characters (mixing chars+bytes leads to exceptions), 
+				# from any supported character (utf-8 being pretty much a superset of all encodings)
+				self.testFileHandlerStdout = logging.StreamHandler(_UnicodeSafeStreamWrapper(self.testFileHandlerStdoutBuffer, writebytes=False, encoding='utf-8'))
+				self.testFileHandlerStdout.setFormatter(PROJECT.formatters.stdout)
+				self.testFileHandlerStdout.setLevel(stdoutHandler.level)
+				pysysLogHandler.setLogHandlersForCurrentThread(defaultLogHandlersForCurrentThread+[self.testFileHandlerStdout])
+
+				# set the output subdirectory and purge contents
+				if os.path.isabs(self.runner.outsubdir):
+					self.outsubdir = os.path.join(self.runner.outsubdir, self.descriptor.id)
+				else:
+					self.outsubdir = os.path.join(self.descriptor.output, self.runner.outsubdir)
+
+				if not self.runner.validateOnly: 
+					if self.runner.cycle <= 1: 
+						deletedir(self.outsubdir)
+					else:
+						# must use lock to avoid deleting the parent dir after we've started creating outdirs for some cycles
+						with global_lock:
+							if self.outsubdir not in TestContainer.__purgedOutputDirs:
+								deletedir(self.outsubdir)
+								TestContainer.__purgedOutputDirs.add(self.outsubdir)
+				
+				if self.runner.cycle > 1: 
+					self.outsubdir = os.path.join(self.outsubdir, 'cycle%d' % (self.cycle+1))
+				mkdir(self.outsubdir)
+
+				# run.log handler
+				runLogEncoding = self.runner.getDefaultFileEncoding('run.log') or locale.getpreferredencoding()
+				self.testFileHandlerRunLog = logging.StreamHandler(_UnicodeSafeStreamWrapper(
+					io.open(os.path.join(self.outsubdir, 'run.log'), 'a', encoding=runLogEncoding), 
+					writebytes=False, encoding=runLogEncoding))
+				self.testFileHandlerRunLog.setFormatter(PROJECT.formatters.runlog)
+				self.testFileHandlerRunLog.setLevel(logging.INFO)
+				if stdoutHandler.level == logging.DEBUG: self.testFileHandlerRunLog.setLevel(logging.DEBUG)
+				pysysLogHandler.setLogHandlersForCurrentThread(defaultLogHandlersForCurrentThread+[self.testFileHandlerStdout, self.testFileHandlerRunLog])
+
+				log.info(62*"=")
+				title = textwrap.wrap(self.descriptor.title.replace('\n','').strip(), 56)
+				log.info("Id   : %s", self.descriptor.id, extra=BaseLogFormatter.tag(LOG_TEST_DETAILS, 0))
+				if len(title)>0:
+					log.info("Title: %s", str(title[0]), extra=BaseLogFormatter.tag(LOG_TEST_DETAILS, 0))
+				for l in title[1:]:
+					log.info("       %s", str(l), extra=BaseLogFormatter.tag(LOG_TEST_DETAILS, 0))
+				if self.runner.cycle > 1:
+					log.info("Cycle: %s", str(self.cycle+1), extra=BaseLogFormatter.tag(LOG_TEST_DETAILS, 0))
+				log.info(62*"=")
 			except KeyboardInterrupt:
 				self.kbrdInt = True
 			
 			except Exception:
 				exc_info.append(sys.exc_info())
-				self.testObj = BaseTest(self.descriptor, self.outsubdir, self.runner)
-			# can't set this in constructor without breaking compatibility, but set it asap after construction
-			del BaseTest._currentTestCycle
-
-		for writer in self.runner.writers:
-			try: 
-				if hasattr(writer, 'processTestStarting'):
-					writer.processTestStarting(testObj=self.testObj, cycle=self.cycle)
-			except Exception: 
-				log.warn("caught %s calling processTestStarting on %s: %s", sys.exc_info()[0], writer.__class__.__name__, sys.exc_info()[1], exc_info=1)
-
-		# execute the test if we can
-		try:
-			if self.descriptor.state != 'runnable':
-				self.testObj.addOutcome(SKIPPED, 'Not runnable', abortOnError=False)
-						
-			elif self.runner.mode and self.runner.mode not in self.descriptor.modes:
-				self.testObj.addOutcome(SKIPPED, "Unable to run test in %s mode"%self.runner.mode, abortOnError=False)
-			
-			elif len(exc_info) > 0:
-				self.testObj.addOutcome(BLOCKED, 'Failed to set up test: %s'%exc_info[0][1], abortOnError=False)
-				for info in exc_info:
-					log.warn("caught %s while setting up test %s: %s", info[0], self.descriptor.id, info[1], exc_info=info)
-					
-			elif self.kbrdInt:
-				log.warn("test interrupt from keyboard")
-				self.testObj.addOutcome(BLOCKED, 'Test interrupt from keyboard', abortOnError=False)
-		
-			else:
+				
+			# import the test class
+			with global_lock:
+				BaseTest._currentTestCycle = (self.cycle+1) if (self.runner.cycle > 1) else 0 # backwards compatible way of passing cycle to BaseTest constructor; safe because of global_lock
 				try:
-					if not self.runner.validateOnly:
-						self.testObj.setup()
-						self.testObj.execute()
-					self.testObj.validate()
-				except AbortExecution as e:
-					del self.testObj.outcome[:]
-					self.testObj.addOutcome(e.outcome, e.value, abortOnError=False, callRecord=e.callRecord)
-					log.warn('Aborted test due to abortOnError set to true')
+					runpypath = self.descriptor.module+'.py'
+					with open(runpypath, 'rb') as runpyfile:
+						runpycode = compile(runpyfile.read(), runpypath, 'exec')
+					runpy_namespace = {}
+					exec(runpycode, runpy_namespace)
+					self.testObj = runpy_namespace[self.descriptor.classname](self.descriptor, self.outsubdir, self.runner)
+					del runpy_namespace
+		
+				except KeyboardInterrupt:
+					self.kbrdInt = True
+				
+				except Exception:
+					exc_info.append(sys.exc_info())
+					self.testObj = BaseTest(self.descriptor, self.outsubdir, self.runner)
+				# can't set this in constructor without breaking compatibility, but set it asap after construction
+				del BaseTest._currentTestCycle
 
-				if self.detectCore(self.outsubdir):
-					self.testObj.addOutcome(DUMPEDCORE, 'Core detected in output subdirectory', abortOnError=False)
-		
-		except KeyboardInterrupt:
-			self.kbrdInt = True
-			self.testObj.addOutcome(BLOCKED, 'Test interrupt from keyboard', abortOnError=False)
+			for writer in self.runner.writers:
+				try: 
+					if hasattr(writer, 'processTestStarting'):
+						writer.processTestStarting(testObj=self.testObj, cycle=self.cycle)
+				except Exception: 
+					log.warn("caught %s calling processTestStarting on %s: %s", sys.exc_info()[0], writer.__class__.__name__, sys.exc_info()[1], exc_info=1)
 
-		except Exception:
-			log.warn("caught %s while running test: %s", sys.exc_info()[0], sys.exc_info()[1], exc_info=1)
-			self.testObj.addOutcome(BLOCKED, '%s (%s)'%(sys.exc_info()[1], sys.exc_info()[0]), abortOnError=False)
-	
-		# call the cleanup method to tear down the test
-		try:
-			self.testObj.cleanup()
-		
-		except KeyboardInterrupt:
-			self.kbrdInt = True
-			self.testObj.addOutcome(BLOCKED, 'Test interrupt from keyboard', abortOnError=False)
+			# execute the test if we can
+			try:
+				if self.descriptor.state != 'runnable':
+					self.testObj.addOutcome(SKIPPED, 'Not runnable', abortOnError=False)
+							
+				elif self.runner.mode and self.runner.mode not in self.descriptor.modes:
+					self.testObj.addOutcome(SKIPPED, "Unable to run test in %s mode"%self.runner.mode, abortOnError=False)
+				
+				elif len(exc_info) > 0:
+					self.testObj.addOutcome(BLOCKED, 'Failed to set up test: %s'%exc_info[0][1], abortOnError=False)
+					for info in exc_info:
+						log.warn("caught %s while setting up test %s: %s", info[0], self.descriptor.id, info[1], exc_info=info)
+						
+				elif self.kbrdInt:
+					log.warn("test interrupt from keyboard")
+					self.testObj.addOutcome(BLOCKED, 'Test interrupt from keyboard', abortOnError=False)
 			
-		# print summary and close file handles
-		try:
-			self.testTime = math.floor(100*(time.time() - self.testStart))/100.0
-			log.info("")
-			log.info("Test duration: %s", ('%.2f secs'%self.testTime), extra=BaseLogFormatter.tag(LOG_DEBUG, 0))
-			log.info("Test final outcome:  %s", LOOKUP[self.testObj.getOutcome()], extra=BaseLogFormatter.tag(LOOKUP[self.testObj.getOutcome()].lower(), 0))
-			if self.testObj.getOutcomeReason() and self.testObj.getOutcome() != PASSED:
-				log.info("Test failure reason: %s", self.testObj.getOutcomeReason(), extra=BaseLogFormatter.tag(LOG_TEST_OUTCOMES, 0))
-			log.info("")
+				else:
+					try:
+						if not self.runner.validateOnly:
+							self.testObj.setup()
+							self.testObj.execute()
+						self.testObj.validate()
+					except AbortExecution as e:
+						del self.testObj.outcome[:]
+						self.testObj.addOutcome(e.outcome, e.value, abortOnError=False, callRecord=e.callRecord)
+						log.warn('Aborted test due to abortOnError set to true')
+
+					if self.detectCore(self.outsubdir):
+						self.testObj.addOutcome(DUMPEDCORE, 'Core detected in output subdirectory', abortOnError=False)
 			
-			self.runner._testThreadsLogHandler.flush()
-			if self.testFileHandlerRunLog: self.testFileHandlerRunLog.stream.close()
-			self.runner._testThreadsLogHandler.setLogHandlersForCurrentThread([])
-		except Exception as ex: # really should never happen so if it does make sure we know why
-			sys.stderr.write('Error in callback for %s: %s\n'%(self.descriptor.id, ex))
-			traceback.print_exc()
+			except KeyboardInterrupt:
+				self.kbrdInt = True
+				self.testObj.addOutcome(BLOCKED, 'Test interrupt from keyboard', abortOnError=False)
+
+			except Exception:
+				log.warn("caught %s while running test: %s", sys.exc_info()[0], sys.exc_info()[1], exc_info=1)
+				self.testObj.addOutcome(BLOCKED, '%s (%s)'%(sys.exc_info()[1], sys.exc_info()[0]), abortOnError=False)
 		
-		# return a reference to self
-		return self
-	
+			# call the cleanup method to tear down the test
+			try:
+				self.testObj.cleanup()
+			
+			except KeyboardInterrupt:
+				self.kbrdInt = True
+				self.testObj.addOutcome(BLOCKED, 'Test interrupt from keyboard', abortOnError=False)
+				
+			# print summary and close file handles
+			try:
+				self.testTime = math.floor(100*(time.time() - self.testStart))/100.0
+				log.info("")
+				log.info("Test duration: %s", ('%.2f secs'%self.testTime), extra=BaseLogFormatter.tag(LOG_DEBUG, 0))
+				log.info("Test final outcome:  %s", LOOKUP[self.testObj.getOutcome()], extra=BaseLogFormatter.tag(LOOKUP[self.testObj.getOutcome()].lower(), 0))
+				if self.testObj.getOutcomeReason() and self.testObj.getOutcome() != PASSED:
+					log.info("Test failure reason: %s", self.testObj.getOutcomeReason(), extra=BaseLogFormatter.tag(LOG_TEST_OUTCOMES, 0))
+				log.info("")
+				
+				pysysLogHandler.flush()
+				if self.testFileHandlerRunLog: self.testFileHandlerRunLog.stream.close()
+			except Exception as ex: # really should never happen so if it does make sure we know why
+				sys.stderr.write('Error in callback for %s: %s\n'%(self.descriptor.id, ex))
+				traceback.print_exc()
+			
+			# return a reference to self
+			return self
+		finally:
+			pysysLogHandler.setLogHandlersForCurrentThread(defaultLogHandlersForCurrentThread)
 	
 	# utility methods
 	def purgeDirectory(self, dir, delTop=False):

--- a/pysys/baserunner.py
+++ b/pysys/baserunner.py
@@ -352,7 +352,8 @@ class BaseRunner(ProcessUser):
 
 			# for suppressing print-as-we-execute in single-threaded mode (at least until outcome is known)
 			singleThreadStdoutDisable = self.threads==1 and self.printLogs!=PrintLogs.ALL
-			assert pysysLogHandler.getLogHandlersForCurrentThread()==[stdoutHandler] # the code below assumes this
+			# the setLogHandlersForCurrentThread invocation below assumes this
+			assert pysysLogHandler.getLogHandlersForCurrentThread()==[stdoutHandler] 
 				
 			for cycle in range(self.cycle):
 				# loop through tests for the cycle

--- a/pysys/basetest.py
+++ b/pysys/basetest.py
@@ -187,10 +187,10 @@ class BaseTest(ProcessUser):
 				self.stopManualTester()
 
 			# first request them all to stop
-			# although we don't yet state this method is thread-safe, make it 
-			# as thread-safe as possible by using swap operations
-			threads, self.__backgroundThreads = list(self.__backgroundThreads), []
-			self.__backgroundThreads = []
+			# although we don't yet state that cleanup() is fully thread-safe, 
+			# do our best (without holding locks while joining threads, obviously)
+			with self.lock:
+				threads, self.__backgroundThreads = list(self.__backgroundThreads), []
 			for th in threads: th.stop()
 			for th in threads: th.join(abortOnError=False)
 		
@@ -281,11 +281,12 @@ class BaseTest(ProcessUser):
 					t.stop() # requests thread to stop but doesn't wait for it to stop
 					t.join()
 		
-		Note that C{BaseTest} is not thread-safe (apart from C{addOutcome} and 
-		the reading of fields like self.output that don't change) so if you 
-		need to use its fields or methods (such as C{startProcess}) from 
+		Note that C{BaseTest} is not thread-safe (apart from C{addOutcome}, 
+		C{startProcess} and the reading of fields like self.output that don't 
+		change) so if you need to use its fields or methods from 
 		background threads, be sure to add your own locking to the foreground 
-		and background threads in your test, including any cleanup functions. 
+		and background threads in your test, including any custom cleanup 
+		functions. 
 		
 		The BaseTest will stop and join all running background threads at the 
 		beginning of cleanup. If a thread doesn't stop within the expected 
@@ -313,7 +314,8 @@ class BaseTest(ProcessUser):
 		"""
 		t = BackgroundThread(self, name=name, target=target, kwargsForTarget=kwargsForTarget)
 		t.thread.start()
-		self.__backgroundThreads.append(t)
+		with self.lock:
+			self.__backgroundThreads.append(t)
 		return t
 
 	# methods to control the manual tester user interface

--- a/pysys/basetest.py
+++ b/pysys/basetest.py
@@ -268,22 +268,23 @@ class BaseTest(ProcessUser):
 		the thread is meant to be finishing. 
 		
 		Example usage::
-		  class PySysTest(BaseTest):
-		    def dosomething(self, stopping, param1, pollingInterval):
-		      while not stopping.is_set():
-			  
-			    # ... do stuff here
-			  
-			    # sleep for pollingInterval, waking up if requested to stop; 
-			    # (hint: ensure this wait time is small to retain 
-			    # responsiveness to Ctrl+C interrupts)
-			    if stopping.wait(pollingInterval): return
+			class PySysTest(BaseTest):
+				def dosomething(self, stopping, log, param1, pollingInterval):
+					log.debug('Message from my thread')
+					while not stopping.is_set():
 		
-		    def execute(self):
-		      t = self.startBackgroundThread('DoSomething1', self.dosomething, {'param1':True, 'pollingInterval':1.0})
-		      ...
-		      t.stop() # requests thread to stop but doesn't wait for it to stop
-		      t.join()
+						# ... do stuff here
+		
+						# sleep for pollingInterval, waking up if requested to stop; 
+						# (hint: ensure this wait time is small to retain 
+						# responsiveness to Ctrl+C interrupts)
+						if stopping.wait(pollingInterval): return
+		
+				def execute(self):
+					t = self.startBackgroundThread('DoSomething1', self.dosomething, {'param1':True, 'pollingInterval':1.0})
+					...
+					t.stop() # requests thread to stop but doesn't wait for it to stop
+					t.join()
 		
 		Note that C{BaseTest} is not thread-safe (apart from C{addOutcome} and 
 		the reading of fields like self.output that don't change) so if you 

--- a/pysys/internal/initlogging.py
+++ b/pysys/internal/initlogging.py
@@ -181,6 +181,7 @@ class DelegatingPerThreadLogHandler(logging.Handler):
 	def setLogHandlersForCurrentThread(self, handlers):
 		self.__threadLocals.handlers = handlers
 		self.__threadLocals.emitFunctions = [(h.level, h.emit) for h in handlers] if handlers else None
+
 	def getLogHandlersForCurrentThread(self):
 		return getattr(self.__threadLocals, 'handlers', None) or []
 	

--- a/pysys/internal/initlogging.py
+++ b/pysys/internal/initlogging.py
@@ -43,11 +43,16 @@ class _UnicodeSafeStreamWrapper(object):
 		@param encoding: encoding which all written bytes/chars are guaranteed to be present in; 
 		if None, will be taken from underlying encoding or getpreferredencoding(). 
 		"""
+		self.__writebytes = writebytes
+		self.__requestedEncoding = encoding
+		self.updateUnderlyingStream(underlying)
+	
+	def updateUnderlyingStream(self, underlying):
+		assert underlying != self # avoid infinite loops
 		self.stream = underlying
 		# on python 2 stdout.encoding=None if redirected, and falling back on getpreferredencoding is the best we can do
-		self.__encoding = encoding or getattr(underlying, 'encoding', None) or locale.getpreferredencoding()
+		self.__encoding = self.__requestedEncoding or getattr(underlying, 'encoding', None) or locale.getpreferredencoding()
 		assert self.__encoding
-		self.__writebytes = writebytes
 	
 	def write(self, s):
 		if not s: return
@@ -81,8 +86,6 @@ class _UnicodeSafeStreamWrapper(object):
 		self.stream = None
 
 
-# class extensions for supporting multi-threaded nature
-
 class ThreadedStreamHandler(logging.StreamHandler):
 	"""Stream handler to only log from the creating thread.
 	
@@ -94,28 +97,20 @@ class ThreadedStreamHandler(logging.StreamHandler):
 	handler to stdout, either immediately or (when multiple threads are in use) 
 	at the end of each test's execution. 
 	
-	@deprecated: For internal use only, do not use. 
+	@deprecated: For internal use and backwards compatibility only, do not use. 
 	"""
-	def __init__(self, strm=None, streamFactory=None):
+	def __init__(self, strm):
 		"""Overrides logging.StreamHandler.__init__.
 		@param strm: the stream
-		@param streamFactory: a function that returns the stream, if strm is not specified. 
 		"""
 		self.threadId = threading.current_thread().ident
-		self.__streamfactory = streamFactory if streamFactory else (lambda:strm)
-		logging.StreamHandler.__init__(self, self.__streamfactory())
+		logging.StreamHandler.__init__(self, strm)
 		
 	def emit(self, record):
 		"""Overrides logging.StreamHandler.emit."""
 		if self.threadId != threading.current_thread().ident: return
 		logging.StreamHandler.emit(self, record)
 
-	def _updateUnderlyingStream(self):
-		""" Update the stream this handler uses by calling again the stream factory; 
-		used only for testing. 
-		"""
-		assert self.stream # otherwise assigning to it wouldn't do anything
-		self.stream = self.__streamfactory()
 
 class ThreadedFileHandler(logging.FileHandler):
 	"""File handler to only log from the creating thread.
@@ -163,6 +158,35 @@ class ThreadFilter(logging.Filterer):
 		if self.threadId != threading.current_thread().ident: return True
 		return False
 
+class DelegatingPerThreadLogHandler(logging.Handler):
+	"""A log handler that delegates emits to a list of handlers, 
+	set on a per-thread basis. If no handlers are setup for this 
+	thread nothing is emitted.
+	
+	Note that calling close() on this handler does not call close 
+	on any of the delegated handlers (since they may 
+	be used by multiple threads, and to avoid leaks we don't keep a 
+	global list of them anyway). 
+	"""
+	def __init__(self):
+		super(DelegatingPerThreadLogHandler, self).__init__()
+		self.__threadLocals = threading.local()
+
+	def setLogHandlersForCurrentThread(self, handlers):
+		self.__threadLocals.handlers = handlers
+		self.__threadLocals.emitFunctions = [(h.level, h.emit) for h in handlers] if handlers else None
+	def getLogHandlersForCurrentThread(self):
+		return getattr(self.__threadLocals, 'handlers', None) or []
+	
+	def emit(self, record):
+		functions = getattr(self.__threadLocals, 'emitFunctions', None) 
+		if functions is not None: 
+			for (hdlrlevel, emitFunction) in functions:
+				# handlers can have different levels, so need to replicate the checking that callHandlers performs
+				if record.levelno >= hdlrlevel:
+					emitFunction(record)
+	def flush(self): 
+		for h in self.getLogHandlersForCurrentThread(): h.flush()
 
 #####################################
 
@@ -177,15 +201,24 @@ rootLogger = logging.getLogger('pysys')
 
 log = rootLogger
 
-stdoutHandler = ThreadedStreamHandler(streamFactory=lambda: _UnicodeSafeStreamWrapper(sys.stdout, writebytes=PY2))
-"""The handler that sends pysys.* log output from the main thread to stdout, 
-including buffered output from completed tests when running in parallel."""
+stdoutHandler = logging.StreamHandler(_UnicodeSafeStreamWrapper(sys.stdout, writebytes=PY2))
+"""The handler that sends pysys.* log output from to stdout, 
+including buffered output from completed tests when running in parallel.
 
+The .stream field can be used to access the wrapper we use throughout 
+pysys to safely write to stdout (with coloring support if enabled). 
+"""
+
+pysysLogHandler = DelegatingPerThreadLogHandler()
+""" The log handler used by PySys. It ignores log messages unless 
+setLogHandlersForCurrentThread has been called on the current thread. 
+"""
 
 # customize the default logging names for display
 logging.addLevelName(50, 'CRIT')
 logging.addLevelName(30, 'WARN')
 stdoutHandler.setLevel(logging.INFO)
 rootLogger.setLevel(logging.DEBUG) # The root logger log level (set to DEBUG as all filtering is done by the handlers).
-rootLogger.addHandler(stdoutHandler)
+rootLogger.addHandler(pysysLogHandler)
+pysysLogHandler.setLogHandlersForCurrentThread([stdoutHandler]) # main thread is by default the only one that writes to stdout
 

--- a/pysys/process/user.py
+++ b/pysys/process/user.py
@@ -819,18 +819,14 @@ class ProcessUser(object):
 			if outcome in FAILS and abortOnError:
 				if callRecord==None: callRecord = self.__callRecord()
 				self.abort(outcome, outcomeReason, callRecord)
-				log.warn(u'%s ... %s %s', outcomeReason, LOOKUP[outcome].lower(), u'[%s]'%','.join(callRecord) if callRecord!=None else u'',
-						 extra=BaseLogFormatter.tag(LOOKUP[outcome].lower(),1))
-			else:
-				log.info(u'%s ... %s', outcomeReason, LOOKUP[outcome].lower(), extra=BaseLogFormatter.tag(LOOKUP[outcome].lower(),1))
 
 			if outcomeReason and printReason:
 				if outcome in FAILS:
 					if callRecord==None: callRecord = self.__callRecord()
-					log.warn('%s ... %s %s', outcomeReason, LOOKUP[outcome].lower(), '[%s]'%','.join(callRecord) if callRecord!=None else '',
+					log.warn(u'%s ... %s %s', outcomeReason, LOOKUP[outcome].lower(), u'[%s]'%','.join(callRecord) if callRecord!=None else u'',
 							 extra=BaseLogFormatter.tag(LOOKUP[outcome].lower(),1))
 				else:
-					log.info('%s ... %s', outcomeReason, LOOKUP[outcome].lower(), extra=BaseLogFormatter.tag(LOOKUP[outcome].lower(),1))
+					log.info(u'%s ... %s', outcomeReason, LOOKUP[outcome].lower(), extra=BaseLogFormatter.tag(LOOKUP[outcome].lower(),1))
 
 	def abort(self, outcome, outcomeReason, callRecord=None):
 		"""Raise an AbortException.

--- a/pysys/process/user.py
+++ b/pysys/process/user.py
@@ -76,7 +76,12 @@ class ProcessUser(object):
 		self.defaultAbortOnError = PROJECT.defaultAbortOnError.lower()=='true' if hasattr(PROJECT, 'defaultAbortOnError') else DEFAULT_ABORT_ON_ERROR
 		self.defaultIgnoreExitStatus = PROJECT.defaultIgnoreExitStatus.lower()=='true' if hasattr(PROJECT, 'defaultIgnoreExitStatus') else True
 		self.__uniqueProcessKeys = {}
+		
 		self.lock = threading.RLock()
+		"""
+		A recursive lock that can be used for protecting the fields of this instance 
+		from access by background threads, as needed. 
+		"""
 
 
 	def __getattr__(self, name):
@@ -200,14 +205,15 @@ class ProcessUser(object):
 			log.warn("Process %r timed out after %d seconds, stopping process", process, timeout, extra=BaseLogFormatter.tag(LOG_TIMEOUTS))
 			process.stop()
 		else:
-			self.processList.append(process)
-			try:
-				if displayName in self.processCount:
-					self.processCount[displayName] = self.processCount[displayName] + 1
-				else:
-			 		self.processCount[displayName] = 1
-			except Exception:
-				pass
+			with self.lock:
+				self.processList.append(process)
+				try:
+					if displayName in self.processCount:
+						self.processCount[displayName] = self.processCount[displayName] + 1
+					else:
+						self.processCount[displayName] = 1
+				except Exception:
+					pass
 		return process	
 
 	def getDefaultEnvirons(self, command=None, **kwargs):
@@ -721,8 +727,9 @@ class ProcessUser(object):
 		e.g. self.addCleanupFunction(lambda: self.cleanlyShutdownProcessX(params))
 		
 		"""
-		if fn and fn not in self.__cleanupFunctions: 
-			self.__cleanupFunctions.append(fn)
+		with self.lock:
+			if fn and fn not in self.__cleanupFunctions: 
+				self.__cleanupFunctions.append(fn)
 
 
 	def cleanup(self):
@@ -735,7 +742,8 @@ class ProcessUser(object):
 		try:
 			# although we don't yet state this method is thread-safe, make it 
 			# as thread-safe as possible by using swap operations
-			cleanupfunctions, self.__cleanupFunctions = self.__cleanupFunctions, []
+			with self.lock:
+				cleanupfunctions, self.__cleanupFunctions = self.__cleanupFunctions, []
 			if cleanupfunctions:
 				log.info('')
 				log.info('cleanup:')
@@ -746,7 +754,8 @@ class ProcessUser(object):
 				except Exception as e:
 					log.exception('Error while running cleanup function: ')
 		finally:
-			processes, self.processList = list(self.processList), []
+			with self.lock:
+				processes, self.processList = self.processList, []
 			for process in processes:
 				try:
 					if process.running(): process.stop()

--- a/pysys/utils/logutils.py
+++ b/pysys/utils/logutils.py
@@ -194,12 +194,10 @@ class ColorLogFormatter(BaseLogFormatter):
 					updatedstdout = sys.stdout
 					sys.stdout = stdoutbak
 				# now update the stream used by our handler
-				assert stdoutHandler.stream # unicodewrapper
-				assert stdoutHandler.stream.stream # actual stream
 				if 'PySysPrintRedirector' in repr(updatedstdout):
-					raise Exception('FOrmatter has redirector: %s'%repr(updatedstdout))
+					raise Exception('Formatter has redirector: %s'%repr(updatedstdout))
 
-				stdoutHandler.stream.stream = updatedstdout
+				stdoutHandler.stream.updateUnderlyingStream(updatedstdout)
 
 		super(ColorLogFormatter, self).__init__(propertiesDict)
 

--- a/pysys/utils/threadutils.py
+++ b/pysys/utils/threadutils.py
@@ -16,13 +16,14 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 """
-Module containing the L{BackgroundThread} class.
+Contains the L{BackgroundThread} class.
 """
 
 import sys, os
 import threading
 import logging
 import time
+import traceback
 from pysys.constants import *
 from pysys.internal.initlogging import pysysLogHandler
 
@@ -32,6 +33,14 @@ class BackgroundThread(object):
 	"""
 	PySys wrapper for a background thread that can receive requests to 
 	stop, and can send log output to the same place as the test's logging. 
+
+	@ivar name: The name specified for this thread when it was created. 
+	
+	@ivar joinTimeoutSecs: The default timeout that will be used for joining 
+	this thread. If not explicitly set this will be L{TIMEOUTS}C{['WaitForProcessStop']}.
+	
+	@ivar exception: The exception object raised by the thread if it has 
+	terminated with an error, or None if not. 
 	"""
 	def __init__(self, owner, name, target, kwargsForTarget):
 		"""
@@ -43,6 +52,7 @@ class BackgroundThread(object):
 		assert name, 'Thread name must always be specified'
 
 		self.log = logging.getLogger('pysys.thread.%s'%name) # name without the owner prefix
+		self.name = name
 		self.owner = owner
 		self.__parentLogHandlers = pysysLogHandler.getLogHandlersForCurrentThread()
 		assert self.__parentLogHandlers, self.__parentLogHandlers
@@ -62,7 +72,7 @@ class BackgroundThread(object):
 		
 		self.__outcomeReported = False
 		self.__kbdrInterrupt = None
-		self.log.info('Starting background thread %r'%self)
+		self.log.info('Starting background thread %s'%self)
 	
 	def __repr__(self): return 'BackgroundThread[%s]'%self.thread.name
 	def __str__(self): return self.name # without owner identifier
@@ -83,10 +93,10 @@ class BackgroundThread(object):
 			self.log.debug('%r completed successfully'%self)
 		except Exception as ex:
 			if self.stopping.is_set():
-				self.log.info('%r raised an exception while being stopped (ignoring) - %s: %s'%(self, ex.__class__.__name__, ex))
+				self.log.info('Background thread %s raised an exception while being stopped (ignoring) - %s: %s'%(self, ex.__class__.__name__, ex))
 				return
 			# this is probably the only place we can really get and show the stack trace
-			self.log.exception('%r Background thread failed - '%self)
+			self.log.exception('Background thread %s failed - '%self)
 			
 			# set this so we can report the BLOCKED outcome
 			self.exception = ex
@@ -106,6 +116,7 @@ class BackgroundThread(object):
 		@return: This instance, in case you wish to do fluent method chaining.  
 		@rtype: L{BackgroundThread}
 		"""
+		self.log.debug('Stop() requested for background thread %s', self)
 		self.stopping.set()
 		return self
 		
@@ -144,7 +155,7 @@ class BackgroundThread(object):
 
 		if self.thread.isAlive() or (not outcomereported):
 			# only log it the first time
-			self.log.info('Joining background thread %r'%self)
+			self.log.info('Joining background thread %s'%self)
 		starttime = time.time()
 		
 		# don't call thread.join for the entire time, since on windows that 
@@ -158,14 +169,20 @@ class BackgroundThread(object):
 				raise
 		
 		if self.thread.isAlive():
-			self.stop() # ensure it stops as quickly as possible
+		
 			if not outcomereported:
-				# TODO: print stack trace for the thread
 				self.owner.addOutcome(TIMEDOUT, 'Background thread %s is still running after waiting for allocated timeout period (%d secs)'%(
-					self.thread.name, timeout), abortOnError=abortOnError)
+					self, timeout), abortOnError=abortOnError)
+				try:
+					self.log.warning('Stack of hanging thread %s: \n%s', str(self), 
+						''.join(traceback.format_stack(sys._current_frames()[self.thread.ident])))
+				except Exception as ex:
+					self.log.debug('Failed to get stack of hanging thread: %s: %s', ex.__class__.__name__, ex)
+			self.stop() # ensure it stops as quickly as possible
+
 		elif self.exception is not None:
 			if not outcomereported:
 				self.owner.addOutcome(BLOCKED, 'Background thread %s failed with %s: %s'%(
-					self.thread.name, self.exception.__class__.__name__, self.exception), abortOnError=abortOnError)
-		elif time.time()-starttime>1:
-			self.log.info('Joined background thread %r in %0.1f seconds', self, (time.time()-starttime))
+					self, self.exception.__class__.__name__, self.exception), abortOnError=abortOnError)
+		elif time.time()-starttime>10: # alert user only if it took a long time
+			self.log.info('Joined background thread %s in %0.1f seconds', self, (time.time()-starttime))

--- a/pysys/utils/threadutils.py
+++ b/pysys/utils/threadutils.py
@@ -168,6 +168,8 @@ class BackgroundThread(object):
 				self.__kbdrInterrupt = ex
 				raise
 		
+		timetaken = time.time()-starttime
+		
 		if self.thread.isAlive():
 		
 			if not outcomereported:
@@ -184,5 +186,5 @@ class BackgroundThread(object):
 			if not outcomereported:
 				self.owner.addOutcome(BLOCKED, 'Background thread %s failed with %s: %s'%(
 					self, self.exception.__class__.__name__, self.exception), abortOnError=abortOnError)
-		elif time.time()-starttime>10: # alert user only if it took a long time
-			self.log.info('Joined background thread %s in %0.1f seconds', self, (time.time()-starttime))
+		elif timetaken >10: # alert user only if it took a long time
+			self.log.info('Joined background thread %s in %0.1f seconds', self, timetaken)

--- a/pysys/utils/threadutils.py
+++ b/pysys/utils/threadutils.py
@@ -35,7 +35,7 @@ class BackgroundThread(object):
 	"""
 	def __init__(self, owner, name, target, kwargsForTarget):
 		"""
-		For details see L{pysys.BaseTest.startBackgroundThread}.
+		For details see L{pysys.basetest.BaseTest.startBackgroundThread}.
 		
 		@param owner: The BaseTest that owns this background thread and is 
 		responsible for ensuring it is terminated during cleanup. 
@@ -100,9 +100,11 @@ class BackgroundThread(object):
 		the thread ought to be checking regularly. 
 		
 		This method returns immediately; if you wish to wait for the 
-		thread to terminate, call L{join} afterwards.
+		thread to terminate, call L{join} afterwards. Calling this repeatedly 
+		has no effect. 
 		
 		@return: This instance, in case you wish to do fluent method chaining.  
+		@rtype: L{BackgroundThread}
 		"""
 		self.stopping.set()
 		return self
@@ -129,8 +131,10 @@ class BackgroundThread(object):
 		Note that unlike Python's `Thread.join` method, infinite timeouts 
 		are not supported. 
 		
-		@param abortOnError: Set to True if you wish this method to raise an 
-		exception if the thread times out or raises an Exception. 
+		@param abortOnError: Set to True if you wish this method to 
+		immediately abort with an exception if the background thread times out 
+		or raises an Exception. The default is False, which adds the failure 
+		outcome but does not raise an exception. 
 		"""
 		outcomereported = self.__outcomeReported
 		self.__outcomeReported = True # only do this once

--- a/pysys/utils/threadutils.py
+++ b/pysys/utils/threadutils.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python
+# PySys System Test Framework, Copyright (C) 2006-2018 M.B.Grieve
+
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+"""
+Module containing the L{BackgroundThread} class.
+"""
+
+import sys, os
+import threading
+import logging
+import time
+from pysys.constants import *
+from pysys.internal.initlogging import pysysLogHandler
+
+__all__ = ['BackgroundThread']
+
+class BackgroundThread(object):
+	"""
+	PySys wrapper for a background thread that can receive requests to 
+	stop, and can send log output to the same place as the test's logging. 
+	"""
+	def __init__(self, owner, name, target, kwargsForTarget):
+		"""
+		For details see L{pysys.BaseTest.startBackgroundThread}.
+		
+		@param owner: The BaseTest that owns this background thread and is 
+		responsible for ensuring it is terminated during cleanup. 
+		"""
+		assert name, 'Thread name must always be specified'
+
+		self.log = logging.getLogger('pysys.thread.%s'%name) # name without the owner prefix
+		self.owner = owner
+		self.__parentLogHandlers = pysysLogHandler.getLogHandlersForCurrentThread()
+		assert self.__parentLogHandlers, self.__parentLogHandlers
+		self.__target = target
+		self.stopping = threading.Event()
+		self.joinTimeoutSecs = TIMEOUTS['WaitForProcessStop']
+		self.exception = None
+
+		kwargs = dict(kwargsForTarget) if kwargsForTarget is not None else {}
+		kwargs['stopping'] = self.stopping
+		kwargs['log'] = self.log
+		self.thread = threading.Thread(name='%s.%s'%(str(owner), name), target=self.__run, kwargs=kwargs)
+		self.thread.daemon = True
+		
+		# add an undocumented alias matching threading.Thread's
+		self.is_alive = self.isAlive
+		
+		self.__outcomeReported = False
+		self.__kbdrInterrupt = None
+		self.log.info('Starting background thread %r'%self)
+	
+	def __repr__(self): return 'BackgroundThread[%s]'%self.thread.name
+	def __str__(self): return self.name # without owner identifier
+	
+	def isAlive(self):
+		"""
+		@return: True if this thread is still running. 
+		@rtype: bool
+		"""
+		return self.thread.isAlive()
+	
+	def __run(self, **kwargs):
+		try:
+			# inherit log handlers from parent, whatever they are
+			pysysLogHandler.setLogHandlersForCurrentThread(self.__parentLogHandlers)
+			self.log.debug('%r starting'%self)
+			self.__target(**kwargs)
+			self.log.debug('%r completed successfully'%self)
+		except Exception as ex:
+			if self.stopping.is_set():
+				self.log.info('%r raised an exception while being stopped (ignoring) - %s: %s'%(self, ex.__class__.__name__, ex))
+				return
+			# this is probably the only place we can really get and show the stack trace
+			self.log.exception('%r Background thread failed - '%self)
+			
+			# set this so we can report the BLOCKED outcome
+			self.exception = ex
+		finally:
+			pysysLogHandler.flush()
+			pysysLogHandler.setLogHandlersForCurrentThread([])
+
+	def stop(self):
+		"""
+		Requests the thread to stop by setting the `stopping` event which 
+		the thread ought to be checking regularly. 
+		
+		This method returns immediately; if you wish to wait for the 
+		thread to terminate, call L{join} afterwards.
+		
+		@return: This instance, in case you wish to do fluent method chaining.  
+		"""
+		self.stopping.set()
+		return self
+		
+	def join(self, timeout=None, abortOnError=False):
+		"""
+		Wait until this thread terminates, and adds a TIMEDOUT or BLOCKED 
+		outcome to the owner test if it times out or raises an exception.
+		
+		If you wish to request the thread to terminate rather than waiting for 
+		it to reach the end of its target function on its own, call L{stop} 
+		before joining the thread. 
+		
+		If a join times out, the thread is automatically requested to stop 
+		as soon as possible. 
+		
+		Note that if the thread raises an Exception after it was requested to 
+		stop this is logged but does not result in a failure outcome, 
+		since failures during cleanup are usually to be expected. 
+		
+		@param timeout: The time in seconds to wait. Usually this should be 
+		left at the default value of None which uses a default timeout 
+		of L{constants.TIMEOUTS}C{['WaitForProcessStop']}. 
+		Note that unlike Python's `Thread.join` method, infinite timeouts 
+		are not supported. 
+		
+		@param abortOnError: Set to True if you wish this method to raise an 
+		exception if the thread times out or raises an Exception. 
+		"""
+		outcomereported = self.__outcomeReported
+		self.__outcomeReported = True # only do this once
+		
+		if not timeout: timeout = self.joinTimeoutSecs
+		assert self.joinTimeoutSecs > 0, self.joinTimeoutSecs
+
+		if self.thread.isAlive() or (not outcomereported):
+			# only log it the first time
+			self.log.info('Joining background thread %r'%self)
+		starttime = time.time()
+		
+		# don't call thread.join for the entire time, since on windows that 
+		# leaves no opportunity to detect keyboard interrupts
+		if self.__kbdrInterrupt: raise self.__kbdrInterrupt # avoid repeatedly joining same thread
+		while self.thread.isAlive() and time.time()-starttime < timeout:
+			try:
+				self.thread.join(1)
+			except KeyboardInterrupt as ex: # progra: no cover
+				self.__kbdrInterrupt = ex
+				raise
+		
+		if self.thread.isAlive():
+			self.stop() # ensure it stops as quickly as possible
+			if not outcomereported:
+				# TODO: print stack trace for the thread
+				self.owner.addOutcome(TIMEDOUT, 'Background thread %s is still running after waiting for allocated timeout period (%d secs)'%(
+					self.thread.name, timeout), abortOnError=abortOnError)
+		elif self.exception is not None:
+			if not outcomereported:
+				self.owner.addOutcome(BLOCKED, 'Background thread %s failed with %s: %s'%(
+					self.thread.name, self.exception.__class__.__name__, self.exception), abortOnError=abortOnError)
+		elif time.time()-starttime>1:
+			self.log.info('Joined background thread %r in %0.1f seconds', self, (time.time()-starttime))


### PR DESCRIPTION
Add BaseTest.startBackgroundThread() helper method, and class to take care of stopping/joining the resulting thread, as well as some nice features like log statements going to the right place - fixes GH-5. Had to do some reorganization of the logging handlers to make this work, but I think the result is simpler (especially compared to previous release 1.3.0)
See changelog diff for more details. 