### PR TITLE
Set daemon attribute instead of using setDaemon method that was deprecated in Python 3.10

### DIFF
--- a/pysys/utils/threadpool.py
+++ b/pysys/utils/threadpool.py
@@ -77,7 +77,7 @@ class WorkerThread(threading.Thread):
 		"""
 		threading.Thread.__init__(self, **kwds)
 		log.debug("[%s] Creating thread for test execution" % self.getName())
-		self.setDaemon(1)
+		self.daemon = True
 		self._requests_queue = requests_queue
 		self._results_queue = results_queue
 		self._poll_timeout = poll_timeout


### PR DESCRIPTION
Fixes #44 