### PR TITLE
Performance reporter API and comparison improvements

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,23 +18,22 @@ PySys 2.1 is under development.
 
 New features:
 
-New features related to reporting of performance result numbers:
+New features related to reporting of performance testing:
 
-- Added ``cpuCount`` to the default ``runDetails`` dictionary, since it's useful information to have available, 
-  especially when performance testing. This is the value returned by Python's ``multiprocessing.cpu_count()`` function. 
-- Added a new performance reporter class `pysys.perf.reporters.JSONPerformanceReporter` which write performance 
+- Added details documentation about how to use PySys for performance testing to the :doc:`/pysys/UserGuide`. 
+- Added a new performance reporter class `pysys.perf.reporters.JSONPerformanceReporter` which writes performance 
   results in a format that's easy to machine-read for handling by other systems. To use this instead of (or as well) 
   as the default CSV reporter, add ``<performance-reporter classname="..."/>`` elements to your project configuration.
 - Added a new performance reporter class `pysys.perf.reporters.PrintSummaryPerformanceReporter` which prints a 
   summary of performance results (including mean and stdDev calculation if aggregating across multiple cycles) at the 
   end of the test run. This performance reporter is now added by default (alongside ``CSVPerformanceReporter``), if 
   not explicit list of ``<performance-reporters>`` has been configured. 
-- The default performance reporter class `pysys.perf.reporters.CSVPerformanceReporter` has a property 
+- The default performance reporter class `pysys.perf.reporters.CSVPerformanceReporter` has a new property 
   called ``aggregateCycles`` which instructs it to automatically rewrite the summary file at the end of a run where you 
   have executed multiple cycles, to give aggregate statistics such as mean and standard deviation (and 
   ``samples``=``cycles``) instead of individual results for each cycle. This is useful when cycling tests locally to 
   generate stable numbers for comparisons while optimizing your application. 
-- Extended performance reporter API. Added a new class `pysys.perf.api.BasePerformanceReporter` for creating 
+- Extended the performance reporter API. Added a new class `pysys.perf.api.BasePerformanceReporter` for creating 
   custom reporters. Now you can have multiple performance reporters in the same project, and configure properties for 
   each using the same ``<property>`` or ``"key"="value"`` XML syntax as for writers. Performance reporters now have an 
   additional ``setup`` method which is called just after `pysys.baserunner.BaseRunner.setup`, and is now the best place 
@@ -42,6 +41,8 @@ New features related to reporting of performance result numbers:
   no longer be used in most cases). 
 - Moved the performance classes from ``pysys.utils.perfreporters`` to `pysys.perf`. The old module is deprecated but 
   will continue to work so this is not a breaking change. 
+- Added ``cpuCount`` to the default ``runDetails`` dictionary, since it's useful information to have available, 
+  especially when performance testing. This is the value returned by Python's ``multiprocessing.cpu_count()`` function. 
 - Added ``reportPerformanceResult`` variable to ``BaseTest``, which can be set to ``True`` by any commands that would 
   make recording of performance results pointless (e.g. enablement of profiling). 
 - If no ``resultDetails`` are specified explicitly when reporting a result in a test that has modes, then the name and 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,24 +22,26 @@ New features related to reporting of performance result numbers:
 
 - Added ``cpuCount`` to the default ``runDetails`` dictionary, since it's useful information to have available, 
   especially when performance testing. This is the value returned by Python's ``multiprocessing.cpu_count()`` function. 
-- Added a new performance reporter class `pysys.utils.perfreporter.JSONPerformanceReporter` which write performance 
+- Added a new performance reporter class `pysys.perf.reporters.JSONPerformanceReporter` which write performance 
   results in a format that's easy to machine-read for handling by other systems. To use this instead of (or as well) 
   as the default CSV reporter, add ``<performance-reporter classname="..."/>`` elements to your project configuration.
-- Added a new performance reporter class `pysys.utils.perfreporter.PrintSummaryPerformanceReporter` which prints a 
+- Added a new performance reporter class `pysys.perf.reporters.PrintSummaryPerformanceReporter` which prints a 
   summary of performance results (including mean and stdDev calculation if aggregating across multiple cycles) at the 
   end of the test run. This performance reporter is now added by default (alongside ``CSVPerformanceReporter``), if 
   not explicit list of ``<performance-reporters>`` has been configured. 
-- The default performance reporter class `pysys.utils.perfreporter.CSVPerformanceReporter` has a property 
+- The default performance reporter class `pysys.perf.reporters.CSVPerformanceReporter` has a property 
   called ``aggregateCycles`` which instructs it to automatically rewrite the summary file at the end of a run where you 
   have executed multiple cycles, to give aggregate statistics such as mean and standard deviation (and 
   ``samples``=``cycles``) instead of individual results for each cycle. This is useful when cycling tests locally to 
   generate stable numbers for comparisons while optimizing your application. 
-- Extended performance reporter API. Added a new class `pysys.utils.perfreporter.BasePerformanceReporter` for creating 
+- Extended performance reporter API. Added a new class `pysys.perf.api.BasePerformanceReporter` for creating 
   custom reporters. Now you can have multiple performance reporters in the same project, and configure properties for 
   each using the same ``<property>`` or ``"key"="value"`` XML syntax as for writers. Performance reporters now have an 
   additional ``setup`` method which is called just after `pysys.baserunner.BaseRunner.setup`, and is now the best place 
   for any initialization (it is recommended to move any such code out of the ``__init__`` constructor which should 
   no longer be used in most cases). 
+- Moved the performance classes from ``pysys.utils.perfreporters`` to `pysys.perf`. The old module is deprecated but 
+  will continue to work so this is not a breaking change. 
 
 Fixes:
 
@@ -48,6 +50,11 @@ Fixes:
 - Fix display of duplicate newlines when setting ``stripWhitespace=False`` in `BaseTest.logFileContents`. 
 - Removed the normal logging prefix from PySys in each `BaseTest.logFileContents` line to avoid distracting from the 
   contents of the file being displayed. 
+
+Deprecations:
+
+- Moved the performance classes from ``pysys.utils.perfreporters`` to `pysys.perf`. The old module is deprecated but 
+  will continue to work so this is not a breaking change. 
 
 -----------------
 What's new in 2.0

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,16 +18,22 @@ PySys 2.1 is under development.
 
 New features:
 
+New features related to reporting of performance result numbers:
+
 - Added ``cpuCount`` to the default ``runDetails`` dictionary, since it's useful information to have available, 
   especially when performance testing. This is the value returned by Python's ``multiprocessing.cpu_count()`` function. 
 - Added a new performance reporter class `pysys.utils.perfreporter.JSONPerformanceReporter` which write performance 
   results in a format that's easy to machine-read for handling by other systems. To use this instead of (or as well) 
   as the default CSV reporter, add ``<performance-reporter classname="..."/>`` elements to your project configuration.
-- The default performance reporter class `pysys.utils.perfreporter.CSVPerformanceReporter` now automatically rewrites 
-  the summary file at the end of a run where you have executed multiple cycles, to give aggregate statistics such as 
-  mean and standard deviation (and ``samples``=``cycles``) instead of individual results for each cycle. This is very 
-  useful when cycling tests locally to generate stable numbers for comparisons while optimizing your application. 
-  The new behaviour can be disabled by setting the ``aggregateCycles`` property on the reporter if needed. 
+- Added a new performance reporter class `pysys.utils.perfreporter.PrintSummaryPerformanceReporter` which prints a 
+  summary of performance results (including mean and stdDev calculation if aggregating across multiple cycles) at the 
+  end of the test run. This performance reporter is now added by default (alongside ``CSVPerformanceReporter``), if 
+  not explicit list of ``<performance-reporters>`` has been configured. 
+- The default performance reporter class `pysys.utils.perfreporter.CSVPerformanceReporter` has a property 
+  called ``aggregateCycles`` which instructs it to automatically rewrite the summary file at the end of a run where you 
+  have executed multiple cycles, to give aggregate statistics such as mean and standard deviation (and 
+  ``samples``=``cycles``) instead of individual results for each cycle. This is useful when cycling tests locally to 
+  generate stable numbers for comparisons while optimizing your application. 
 - Extended performance reporter API. Added a new class `pysys.utils.perfreporter.BasePerformanceReporter` for creating 
   custom reporters. Now you can have multiple performance reporters in the same project, and configure properties for 
   each using the same ``<property>`` or ``"key"="value"`` XML syntax as for writers. Performance reporters now have an 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,8 +25,9 @@ New features:
   mean and standard deviation (and ``samples``=``cycles``) instead of individual results for each cycle. This is very 
   useful when cycling tests locally to generate stable numbers for comparisons while optimizing your application. 
   The new behaviour can be disabled by setting the ``aggregateCycles`` property on the reporter if needed. 
-- Extended performance reporter API. Now you can have multiple performance reporters, and configure properties for each 
-  using the same ``<property>`` or ``"key"="value"`` XML syntax as for writers. Performance reporters now have an 
+- Extended performance reporter API. Added a new class `pysys.utils.perfreporter.BasePerformanceReporter` for creating 
+  custom reporters. Now you can have multiple performance reporters in the same project, and configure properties for 
+  each using the same ``<property>`` or ``"key"="value"`` XML syntax as for writers. Performance reporters now have an 
   additional ``setup`` method which is called just after `pysys.baserunner.BaseRunner.setup`, and is now the best place 
   for any initialization (it is recommended to move any such code out of the ``__init__`` constructor which should 
   no longer be used in most cases). 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,8 @@ PySys 2.1 is under development.
 
 New features:
 
-- XXX
+- Added ``cpuCount`` to the default ``runDetails`` dictionary, since it's useful information to have available, 
+  especially when performance testing. This is the value returned by Python's ``multiprocessing.cpu_count()`` function. 
 
 Fixes:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -44,6 +44,8 @@ New features related to reporting of performance result numbers:
   will continue to work so this is not a breaking change. 
 - Added ``reportPerformanceResult`` variable to ``BaseTest``, which can be set to ``True`` by any commands that would 
   make recording of performance results pointless (e.g. enablement of profiling). 
+- If no ``resultDetails`` are specified explicitly when reporting a result in a test that has modes, then the name and 
+  parameters from the test's mode will be recorded as the ``resultDetails``. 
 
 Fixes:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -45,6 +45,9 @@ Fixes:
 
 - Fix bug in which a directory named ``!Input_dir_if_present_else_testDir!`` could be created by ``pysys make``. 
 - Fix a rare circular dependency import issue with ``pysys.constants.Project`` / ``PROJECT``. 
+- Fix display of duplicate newlines when setting ``stripWhitespace=False`` in `BaseTest.logFileContents`. 
+- Removed the normal logging prefix from PySys in each `BaseTest.logFileContents` line to avoid distracting from the 
+  contents of the file being displayed. 
 
 -----------------
 What's new in 2.0

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,9 @@ New features:
 
 - Added ``cpuCount`` to the default ``runDetails`` dictionary, since it's useful information to have available, 
   especially when performance testing. This is the value returned by Python's ``multiprocessing.cpu_count()`` function. 
+- Added a new performance reporter class `pysys.utils.perfreporter.JSONPerformanceReporter` which write performance 
+  results in a format that's easy to machine-read for handling by other systems. To use this instead of (or as well) 
+  as the default CSV reporter, add ``<performance-reporter classname="..."/>`` elements to your project configuration.
 - The default performance reporter class `pysys.utils.perfreporter.CSVPerformanceReporter` now automatically rewrites 
   the summary file at the end of a run where you have executed multiple cycles, to give aggregate statistics such as 
   mean and standard deviation (and ``samples``=``cycles``) instead of individual results for each cycle. This is very 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -42,6 +42,8 @@ New features related to reporting of performance result numbers:
   no longer be used in most cases). 
 - Moved the performance classes from ``pysys.utils.perfreporters`` to `pysys.perf`. The old module is deprecated but 
   will continue to work so this is not a breaking change. 
+- Added ``reportPerformanceResult`` variable to ``BaseTest``, which can be set to ``True`` by any commands that would 
+  make recording of performance results pointless (e.g. enablement of profiling). 
 
 Fixes:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,11 @@ New features:
 
 - Added ``cpuCount`` to the default ``runDetails`` dictionary, since it's useful information to have available, 
   especially when performance testing. This is the value returned by Python's ``multiprocessing.cpu_count()`` function. 
+- Extended performance reporter API. Now you can have multiple performance reporters, and configure properties for each 
+  using the same ``<property>`` or ``"key"="value"`` XML syntax as for writers. Performance reporters now have an 
+  additional ``setup`` method which is called just after `pysys.baserunner.BaseRunner.setup`, and is now the best place 
+  for any initialization (it is recommended to move any such code out of the ``__init__`` constructor which should 
+  no longer be used in most cases). 
 
 Fixes:
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,11 @@ New features:
 
 - Added ``cpuCount`` to the default ``runDetails`` dictionary, since it's useful information to have available, 
   especially when performance testing. This is the value returned by Python's ``multiprocessing.cpu_count()`` function. 
+- The default performance reporter class `pysys.utils.perfreporter.CSVPerformanceReporter` now automatically rewrites 
+  the summary file at the end of a run where you have executed multiple cycles, to give aggregate statistics such as 
+  mean and standard deviation (and ``samples``=``cycles``) instead of individual results for each cycle. This is very 
+  useful when cycling tests locally to generate stable numbers for comparisons while optimizing your application. 
+  The new behaviour can be disabled by setting the ``aggregateCycles`` property on the reporter if needed. 
 - Extended performance reporter API. Now you can have multiple performance reporters, and configure properties for each 
   using the same ``<property>`` or ``"key"="value"`` XML syntax as for writers. Performance reporters now have an 
   additional ``setup`` method which is called just after `pysys.baserunner.BaseRunner.setup`, and is now the best place 

--- a/docs/pysys/BaseTest.rst
+++ b/docs/pysys/BaseTest.rst
@@ -104,6 +104,10 @@ can be accessed via instance attributes on ``self``:
   or performance-measuring test. Typically this would be set in an individual testcase, or in the `setup` method of 
   a `BaseTest` subclass based on groups in the ``self.descriptor`` that indicate what kind of test this is.
 
+- ``self.disablePerformanceReporting`` *(bool)*: Set this to True to request that no performance figures are recorded. 
+  For example you might dynamically set this to True when a test is using options such as profiling or code coverage 
+  that would make the results meaningless. 
+
 Additional variables that affect only the behaviour of a single method are documented in the associated method. 
 
 There is also a field for each test plugin listed in the project configuration. Plugins provide additional 

--- a/docs/pysys/UserGuide.rst
+++ b/docs/pysys/UserGuide.rst
@@ -630,6 +630,12 @@ red or green colour is a regression or improvement that is statistically signifi
 
 Test ids and structuring large projects
 ---------------------------------------
+Firstly, try to have everything in a single PySys project if possible. Use subdirectories to structure your tests, 
+but don't separate into different PySys projects unless it's for testing a totally different component with different 
+testing needs. Keeping everything in the same project gives you the ability to run all your tests 
+(unit/correctness/perf) from a single command line which could be useful in the future even if you don't need it right 
+now. 
+
 Each test has a unique ``id`` which is used in various places such as when 
 reporting passed/failed outcomes. By default the id is just the name of the 
 directory containing the ``pysystest.*`` file. 

--- a/pysys/__init__.py
+++ b/pysys/__init__.py
@@ -28,7 +28,7 @@ implementations of PySys classes described in this API reference:
 
 	- `pysys.baserunner.BaseRunner` to customize orchestration of all the tests in a test run. 
 	- `pysys.writer` classes to customize how test outcomes are recorded.
-	- `pysys.utils.perfreporter.CSVPerformanceReporter` to customize how numeric performance results are reported.
+	- `pysys.perf` to customize how numeric performance results are reported.
 	- `pysys.config.descriptor.DescriptorLoader` to customize how PySys find and runs tests (e.g. to support running tests 
 	  from other frameworks within PySys). 
 	- `pysys.utils.logutils.BaseLogFormatter` for advanced customization of log message format.

--- a/pysys/baserunner.py
+++ b/pysys/baserunner.py
@@ -32,13 +32,8 @@ import warnings
 import difflib
 import importlib
 import multiprocessing
-
-if sys.version_info[0] == 2:
-	from StringIO import StringIO
-	import Queue as queue
-else:
-	from io import StringIO
-	import queue
+from io import StringIO
+import queue
 
 import pysys
 from pysys.constants import *
@@ -703,7 +698,7 @@ class BaseRunner(ProcessUser):
 			# with the perf output
 			for perfreporter in self.performanceReporters:
 					try: perfreporter.cleanup()
-					except Exception as ex: 
+					except Exception as ex: # pragma: no cover
 						log.warning("Caught %s performing performance reporter cleanup: %s", sys.exc_info()[0].__name__, sys.exc_info()[1], exc_info=1)
 						sys.stderr.write('Caught exception performing performance reporter cleanup: %s\n'%traceback.format_exc()) # useful to have it on stderr too, esp during development
 						fatalerrors.append('Failed to cleanup performance reporter %s: %s'%(repr(perfreporter), ex))
@@ -843,13 +838,13 @@ class BaseRunner(ProcessUser):
 				# if only difference is cycle (i.e. different testobj but same test id) then allow, but
 				# make sure we report error if this test tries to report same key more than once, or if it
 				# overlaps with another test's result keys
-				if previd == testObj.descriptor.id and prevcycle==testObj.testCycle:
+				if previd == testObj.descriptor.id and prevcycle==testObj.testCycle: # pragma: no cover
 					testObj.addOutcome(BLOCKED, 'Cannot report performance result as resultKey was already used by this test: "%s"'%(resultKey))
 					return
-				elif previd != testObj.descriptor.id: 
+				elif previd != testObj.descriptor.id: # pragma: no cover
 					testObj.addOutcome(BLOCKED, 'Cannot report performance result as resultKey was already used - resultKey must be unique across all tests: "%s" (already used by %s)'%(resultKey, previd))
 					return
-				elif prevdetails != d: 
+				elif prevdetails != d: # pragma: no cover
 					# prevent different cycles of same test with different resultdetails 
 					testObj.addOutcome(BLOCKED, 'Cannot report performance result as resultKey was already used by a different cycle of this test with different resultDetails - resultKey must be unique across all tests and modes: "%s" (this test resultDetails: %s; previous resultDetails: %s)'%(resultKey, list(d.items()), list(prevdetails.items()) ))
 					return
@@ -862,7 +857,7 @@ class BaseRunner(ProcessUser):
 		if unit in self.performanceReporters[0].unitAliases: unit = self.performanceReporters[0].unitAliases[unit]
 		assert isinstance(unit, pysys.perf.api.PerformanceUnit), repr(unit)
 
-		if testObj.getOutcome().isFailure():
+		if testObj.getOutcome().isFailure(): # pragma: no cover
 			testObj.log.warning('Performance result "%s" will not be recorded as test has failed so results could be invalid', resultKey)
 			return
 		

--- a/pysys/baserunner.py
+++ b/pysys/baserunner.py
@@ -558,7 +558,6 @@ class BaseRunner(ProcessUser):
 			p.summaryFile = p.summaryfile
 			
 			self.performanceReporters.append(p)
-		if self.performanceReporters: self.performanceReporters[0].isPrimaryReporter = True
 				
 		class PySysPrintRedirector(object):
 			def __init__(self):

--- a/pysys/baserunner.py
+++ b/pysys/baserunner.py
@@ -151,7 +151,9 @@ class BaseRunner(ProcessUser):
 	:ivar bool ~.purge: Indicates that all files other than ``run.log`` should be deleted from the output directory 
 		unless the test fails; this corresponds to the ``--purge`` command line argument. 
 
-	:ivar int ~.cycle: The number of times each test should be cycled; this corresponds to the ``--cycle`` command line argument. 
+	:ivar int ~.cycles: The total number of times each test should be cycled; this corresponds to the ``--cycle`` command line argument. 
+		(added in PySys v2.1). 
+	:ivar int ~.cycle: Old name, identical to ``cycles``. 
 
 	:ivar str ~.mode: No longer used. 
 
@@ -202,7 +204,7 @@ class BaseRunner(ProcessUser):
 
 		self.record = record
 		self.purge = purge
-		self.cycle = cycle
+		self.cycle = self.cycles = cycle
 		self.threads = threads
 		self.outsubdir = outsubdir
 		self.descriptors = descriptors

--- a/pysys/baserunner.py
+++ b/pysys/baserunner.py
@@ -554,7 +554,7 @@ class BaseRunner(ProcessUser):
 			pysys.utils.misc.setInstanceVariablesFromDict(p, perfOptionsDict)
 			
 			# for backwards compat permit "summaryfile" as well as summaryFile
-			p.summaryfile = p.summaryfile or p.summaryFile
+			p.summaryfile = p.summaryfile or getattr(p, 'summaryFile', '')
 			p.summaryFile = p.summaryfile
 			
 			self.performanceReporters.append(p)
@@ -709,11 +709,6 @@ class BaseRunner(ProcessUser):
 					except Exception as ex: 
 						log.warning("Caught %s performing performance reporter cleanup: %s", sys.exc_info()[0].__name__, sys.exc_info()[1], exc_info=1)
 						fatalerrors.append('Failed to cleanup performance reporter %s: %s'%(repr(perfreporter), ex))
-			
-			# If user explicitly asked for it, or if doing a multi-cycle perf run, then display a summary at end
-			if self.getXArg('printPerfSummary', default=self.cycles>1):
-				log.debug('Will printPerfSummary')
-				self.performanceReporters[0].printPerfSummary()
 			
 			# perform cleanup on the test writers - this also takes care of logging summary results
 			with self.__resultWritingLock:

--- a/pysys/baserunner.py
+++ b/pysys/baserunner.py
@@ -789,6 +789,16 @@ class BaseRunner(ProcessUser):
 		# call the hook for end of test execution
 		self.testComplete(container.testObj, container.outsubdir)
 
+	def reportPerformanceResult(self, testObj, value, resultKey, unit, **kwargs):
+		"""
+		Reports a new performance number to the configured performance reporters. See `pysys.basetest.reportPerformanceResult` 
+		for details of the arguments. 
+		
+		:meta private: Currently internal; may make this public in a future release if we decide it's useful.
+		"""
+		for p in self.performanceReporters:
+			p.reportResult(testObj, value, resultKey, unit, **kwargs)
+
 	def reportTestOutcome(self, testObj, testStart, testDurationSecs, cycle=0, runLogOutput=u'', **kwargs):
 		"""
 		Records the result of a completed test, including notifying any configured writers, and writing the 

--- a/pysys/baserunner.py
+++ b/pysys/baserunner.py
@@ -708,6 +708,7 @@ class BaseRunner(ProcessUser):
 					try: perfreporter.cleanup()
 					except Exception as ex: 
 						log.warning("Caught %s performing performance reporter cleanup: %s", sys.exc_info()[0].__name__, sys.exc_info()[1], exc_info=1)
+						sys.stderr.write('Caught exception performing performance reporter cleanup: %s\n'%traceback.format_exc()) # useful to have it on stderr too, esp during development
 						fatalerrors.append('Failed to cleanup performance reporter %s: %s'%(repr(perfreporter), ex))
 			
 			# perform cleanup on the test writers - this also takes care of logging summary results

--- a/pysys/baserunner.py
+++ b/pysys/baserunner.py
@@ -52,7 +52,6 @@ from pysys.utils.pycompat import *
 from pysys.internal.initlogging import _UnicodeSafeStreamWrapper, pysysLogHandler
 from pysys.writer import ConsoleSummaryResultsWriter, ConsoleProgressResultsWriter, BaseSummaryResultsWriter, BaseProgressResultsWriter, ArtifactPublisher
 import pysys.utils.allocport
-import pysys.utils.perfreporter
 
 global_lock = threading.Lock() # internal, do not use
 
@@ -546,7 +545,6 @@ class BaseRunner(ProcessUser):
 		
 		# must construct perf reporters here in start(), since if we did it in baserunner constructor, runner 
 		# might not be fully constructed yet
-		from pysys.utils.perfreporter import CSVPerformanceReporter
 		self.performanceReporters = []
 		for perfcls, perfOptionsDict in self.project.perfReporterConfig:
 			p = perfcls(self.project, perfOptionsDict.get('summaryfile',''), self.outsubdir, runner=self)
@@ -862,7 +860,7 @@ class BaseRunner(ProcessUser):
 
 		# Use the unit aliases of the first performance reporter (to avoid the need to worry about syncing between different reporters)
 		if unit in self.performanceReporters[0].unitAliases: unit = self.performanceReporters[0].unitAliases[unit]
-		assert isinstance(unit, pysys.utils.perfreporter.PerformanceUnit), repr(unit)
+		assert isinstance(unit, pysys.perf.api.PerformanceUnit), repr(unit)
 
 		if testObj.getOutcome().isFailure():
 			testObj.log.warning('Performance result "%s" will not be recorded as test has failed so results could be invalid', resultKey)
@@ -958,7 +956,7 @@ class BaseRunner(ProcessUser):
 			the ``outDirName`` in the filename, so that artifacts from multiple test runs/platforms do not clash. 
 		:param str category: A string identifying what kind of artifact this is, e.g. 
 			"TestOutputArchive" and "TestOutputArchiveDir" (from `pysys.writer.TestOutputArchiveWriter`) or 
-			"CSVPerformanceReport" (from `pysys.utils.perfreporter.CSVPerformanceReporter`). 
+			"CSVPerformanceReport" (from `pysys.perf.reporters.CSVPerformanceReporter`). 
 			If you create your own category, be sure to add an org/company name prefix to avoid clashes.
 			Use alphanumeric characters and underscores only. 
 		"""

--- a/pysys/baserunner.py
+++ b/pysys/baserunner.py
@@ -31,6 +31,7 @@ import shlex
 import warnings
 import difflib
 import importlib
+import multiprocessing
 
 if sys.version_info[0] == 2:
 	from StringIO import StringIO
@@ -327,9 +328,10 @@ class BaseRunner(ProcessUser):
 		self.runDetails = collections.OrderedDict()
 		for p in ['outDirName', 'hostname']:
 			self.runDetails[p] = self.project.properties[p]
+		self.runDetails['cpuCount'] = multiprocessing.cpu_count()		
 		if threads>1: self.runDetails['testThreads'] = str(threads)
 		self.runDetails['os'] = platform.platform().replace('-',' ')
-		
+
 		# escape windows \ chars (which does limit the expressive power, but is likely to be more helpful than not)
 		commitCmd = shlex.split(self.project.properties.get('versionControlGetCommitCommand','').replace('\\', '\\\\'))
 		import subprocess

--- a/pysys/baserunner.py
+++ b/pysys/baserunner.py
@@ -551,6 +551,7 @@ class BaseRunner(ProcessUser):
 			p.pluginProperties = perfOptionsDict
 			pysys.utils.misc.setInstanceVariablesFromDict(p, perfOptionsDict)
 			self.performanceReporters.append(p)
+		if self.performanceReporters: self.performanceReporters[0].isPrimaryReporter = True
 				
 		class PySysPrintRedirector(object):
 			def __init__(self):

--- a/pysys/basetest.py
+++ b/pysys/basetest.py
@@ -1484,9 +1484,8 @@ class BaseTest(ProcessUser):
 		return False
 
 	def reportPerformanceResult(self, value, resultKey, unit, toleranceStdDevs=None, resultDetails=None):
-		""" Reports a new performance number to the performance ``csv`` file, with an associated unique string key 
+		""" Reports a new performance number to the configured performance reporters, with an associated unique string key 
 		that identifies it for comparison purposes.
-		
 		
 		Where possible it is better to report the rate at which an operation can be performed (e.g. throughput)
 		rather than the total time taken, since this allows the number of iterations to be increased without affecting 
@@ -1536,8 +1535,7 @@ class BaseTest(ProcessUser):
 			L{pysys.utils.perfreporter.CSVPerformanceReporter.getRunDetails}.
 
 		"""
-		for p in self.runner.performanceReporters:
-			p.reportResult(self, value, resultKey, unit, toleranceStdDevs=toleranceStdDevs, resultDetails=resultDetails)
+		self.runner.reportPerformanceResult(self, value, resultKey, unit, toleranceStdDevs=toleranceStdDevs, resultDetails=resultDetails)
 			
 	def getDefaultFileEncoding(self, file, **xargs):
 		"""

--- a/pysys/basetest.py
+++ b/pysys/basetest.py
@@ -61,6 +61,9 @@ class BaseTest(ProcessUser):
 		self.output = os.path.join(descriptor.testDir, descriptor.output, outsubdir).rstrip('/\\.')
 		self.reference = os.path.join(descriptor.testDir, descriptor.reference).rstrip('/\\.')
 		self.runner = runner
+
+		self.disablePerformanceReporting = False
+
 		self.mode = descriptor.mode
 		# NB: we don't set self.mode.params as keyword arguments since it'd be easy to overwrite a class/instance 
 		# variable unintentionally with unpredictable results; accessing explicitly with self.mode is fine 
@@ -1507,6 +1510,10 @@ class BaseTest(ProcessUser):
 				'Fibonacci sequence calculation rate using %s with different units' % self.mode, 
 				unit=PerformanceUnit('kilo_fibonacci/s', biggerIsBetter=True))
 
+		If the current test is executed with unusual options (e.g. enabling a profiler or code coverage) that would 
+		invalidate performance numbers, you can set ``self.disablePerformanceReporting = True`` to prevent 
+		``reportPerformanceResult`` calls from doing anything. 
+
 		:param value: The numeric value to be reported. If a str is provided, it will be converted to a float.
 
 		:param resultKey: A unique string that fully identifies what was measured, which will be
@@ -1534,7 +1541,10 @@ class BaseTest(ProcessUser):
 			all tests in this PySys execution, which can be customized with a runner plugin.
 
 		"""
-		self.runner.reportPerformanceResult(self, value, resultKey, unit, toleranceStdDevs=toleranceStdDevs, resultDetails=resultDetails)
+		if self.disablePerformanceReporting:
+			self.log.info('Not recording performance result due to disablePerformanceReporting flag: %s = %s %s', resultKey, value, unit)
+		else:
+			self.runner.reportPerformanceResult(self, value, resultKey, unit, toleranceStdDevs=toleranceStdDevs, resultDetails=resultDetails)
 			
 	def getDefaultFileEncoding(self, file, **xargs):
 		"""

--- a/pysys/basetest.py
+++ b/pysys/basetest.py
@@ -1501,7 +1501,7 @@ class BaseTest(ProcessUser):
 				resultDetails=[('mode',self.mode)])
 
 		While use of standard units such as '/s', 's' or 'ns' (nano-seconds) is recommended, custom units can be 
-		provided when needed using `pysys.utils.perfreporter.PerformanceUnit`::
+		provided when needed using `pysys.perf.api.PerformanceUnit`::
 		
 			self.reportPerformanceResult(int(iterations)/float(calctime)/1000, 
 				'Fibonacci sequence calculation rate using %s with different units' % self.mode, 
@@ -1520,9 +1520,9 @@ class BaseTest(ProcessUser):
 			towards the end of the string. It should be as concise as possible (given the above).
 
 		:param unit: Identifies the unit the value is measured in, including whether bigger numbers are better or
-			worse (used to determine improvement or regression). Must be an instance of L{pysys.utils.perfreporter.PerformanceUnit}.
-			In most cases, use L{pysys.utils.perfreporter.PerformanceUnit.SECONDS} (e.g. for latency) or
-			L{pysys.utils.perfreporter.PerformanceUnit.PER_SECOND} (e.g. for throughput); the string literals 's' and '/s' can be
+			worse (used to determine improvement or regression). Must be an instance of L{pysys.perf.api.PerformanceUnit}.
+			In most cases, use L{pysys.perf.api.PerformanceUnit.SECONDS} (e.g. for latency) or
+			L{pysys.perf.api.PerformanceUnit.PER_SECOND} (e.g. for throughput); the string literals 's' and '/s' can be
 			used as a shorthand for those PerformanceUnit instances.
 		
 		:param toleranceStdDevs: (optional) A float that indicates how many standard deviations away from the mean a
@@ -1530,9 +1530,8 @@ class BaseTest(ProcessUser):
 		
 		:param resultDetails: (optional) A dictionary of detailed information about this specific result 
 			and/or test that should be recorded together with the result, for example detailed information about what mode 
-			or versions the test is measuring. Note this is separate from the global run details shared across 
-			all tests in this PySys execution, which can be customized by overriding 
-			L{pysys.utils.perfreporter.CSVPerformanceReporter.getRunDetails}.
+			or versions the test is measuring. Note this is separate from the global "run details" shared across 
+			all tests in this PySys execution, which can be customized with a runner plugin.
 
 		"""
 		self.runner.reportPerformanceResult(self, value, resultKey, unit, toleranceStdDevs=toleranceStdDevs, resultDetails=resultDetails)

--- a/pysys/basetest.py
+++ b/pysys/basetest.py
@@ -1537,10 +1537,17 @@ class BaseTest(ProcessUser):
 		
 		:param resultDetails: (optional) A dictionary of detailed information about this specific result 
 			and/or test that should be recorded together with the result, for example detailed information about what mode 
-			or versions the test is measuring. Note this is separate from the global "run details" shared across 
+			or versions the test is measuring. Note this result-specific, unlike the global "run details" shared across 
 			all tests in this PySys execution, which can be customized with a runner plugin.
+			If no resultDetails are specified explicitly then parameters from the test's mode will be used if present. 
 
 		"""
+		if resultDetails is None and self.mode:
+			# useful information to have available
+			resultDetails = {'mode': self.mode.name}
+			resultDetails.update(self.mode.params)
+		
+		
 		if self.disablePerformanceReporting:
 			self.log.info('Not recording performance result due to disablePerformanceReporting flag: %s = %s %s', resultKey, value, unit)
 		else:

--- a/pysys/basetest.py
+++ b/pysys/basetest.py
@@ -1537,7 +1537,7 @@ class BaseTest(ProcessUser):
 		
 		:param resultDetails: (optional) A dictionary of detailed information about this specific result 
 			and/or test that should be recorded together with the result, for example detailed information about what mode 
-			or versions the test is measuring. Note this result-specific, unlike the global "run details" shared across 
+			or versions the test is measuring. Note this is result-specific, unlike the global "run details" shared across 
 			all tests in this PySys execution, which can be customized with a runner plugin.
 			If no resultDetails are specified explicitly then parameters from the test's mode will be used if present. 
 

--- a/pysys/basetest.py
+++ b/pysys/basetest.py
@@ -733,7 +733,7 @@ class BaseTest(ProcessUser):
 			seq = difflib.SequenceMatcher(None, v1, v2, autojunk=False)
 			
 			matches = seq.get_matching_blocks()
-			lastmatch = matches[-1] if len(matches)==2 else matches[-2] # may be of zero size
+			lastmatch = matches[-1] if len(matches) in [2,1] else matches[-2] # may be of zero size
 			
 			# Find values of ijk such that vN[iN:jN] is a matching prefix and vN[kN:] is a matching suffix
 			# Colouring will be red, white(first match, if any), red, white(last match, if any)

--- a/pysys/config/descriptor.py
+++ b/pysys/config/descriptor.py
@@ -507,7 +507,7 @@ class TestMode(str): # subclasses string to retain compatibility for tests that 
 		runs in this mode. 
 		
 	:ivar bool ~.isPrimary: Indicates whether this is a primary mode, 
-		one that executes by default even when not explicity requested with a commnad line option such as ``--modes=ALL``)
+		one that executes by default even when not explicity requested with a command line option such as ``--modes=ALL``. 
 
 	.. versionadded:: 2.0
 

--- a/pysys/config/project.py
+++ b/pysys/config/project.py
@@ -283,13 +283,16 @@ class _XMLProjectParser(object):
 
 	def getPerformanceReporterDetails(self):
 		nodeList = self.root.getElementsByTagName('performance-reporter')
-		cls, optionsDict = self._parseClassAndConfigDict(nodeList[0] if nodeList else None, 'pysys.utils.perfreporter.CSVPerformanceReporter')
-			
-		summaryfile = optionsDict.pop('summaryfile', '')
-		summaryfile = self.expandProperties(summaryfile, default=None, name='performance-reporter summaryfile')
-		if optionsDict: raise UserError('Unexpected performancereporter attribute(s): '+', '.join(list(optionsDict.keys())))
+		results = []
+		for n in nodeList:
+			cls, optionsDict = self._parseClassAndConfigDict(nodeList[0] if nodeList else None, 'pysys.utils.perfreporter.CSVPerformanceReporter')
+			optionsDict['summaryfile'] = self.expandProperties(optionsDict.get('summaryfile', ''), default=None, name='performance-reporter summaryfile')
+			results.append( (cls, optionsDict) )
 		
-		return cls, summaryfile
+		if not results: # add a default one
+			results.append( self._parseClassAndConfigDict(None, 'pysys.utils.perfreporter.CSVPerformanceReporter') )
+			
+		return results
 
 	def getProjectHelp(self):
 		help = ''

--- a/pysys/config/project.py
+++ b/pysys/config/project.py
@@ -285,13 +285,13 @@ class _XMLProjectParser(object):
 		nodeList = self.root.getElementsByTagName('performance-reporter')
 		results = []
 		for n in nodeList:
-			cls, optionsDict = self._parseClassAndConfigDict(n, 'pysys.utils.perfreporter.CSVPerformanceReporter')
+			cls, optionsDict = self._parseClassAndConfigDict(n, 'pysys.perf.reporters.CSVPerformanceReporter')
 			optionsDict['summaryfile'] = self.expandProperties(optionsDict.get('summaryfile', ''), default=None, name='performance-reporter summaryfile')
 			results.append( (cls, optionsDict) )
 		
 		if not results: # add the defaults
-			results.append( self._parseClassAndConfigDict(None, 'pysys.utils.perfreporter.CSVPerformanceReporter') )
-			results.append( self._parseClassAndConfigDict(None, 'pysys.utils.perfreporter.PrintSummaryPerformanceReporter') )
+			results.append( self._parseClassAndConfigDict(None, 'pysys.perf.reporters.CSVPerformanceReporter') )
+			results.append( self._parseClassAndConfigDict(None, 'pysys.perf.reporters.PrintSummaryPerformanceReporter') )
 			
 		return results
 

--- a/pysys/config/project.py
+++ b/pysys/config/project.py
@@ -289,8 +289,9 @@ class _XMLProjectParser(object):
 			optionsDict['summaryfile'] = self.expandProperties(optionsDict.get('summaryfile', ''), default=None, name='performance-reporter summaryfile')
 			results.append( (cls, optionsDict) )
 		
-		if not results: # add a default one
+		if not results: # add the defaults
 			results.append( self._parseClassAndConfigDict(None, 'pysys.utils.perfreporter.CSVPerformanceReporter') )
+			results.append( self._parseClassAndConfigDict(None, 'pysys.utils.perfreporter.PrintSummaryPerformanceReporter') )
 			
 		return results
 

--- a/pysys/config/project.py
+++ b/pysys/config/project.py
@@ -285,7 +285,7 @@ class _XMLProjectParser(object):
 		nodeList = self.root.getElementsByTagName('performance-reporter')
 		results = []
 		for n in nodeList:
-			cls, optionsDict = self._parseClassAndConfigDict(nodeList[0] if nodeList else None, 'pysys.utils.perfreporter.CSVPerformanceReporter')
+			cls, optionsDict = self._parseClassAndConfigDict(n, 'pysys.utils.perfreporter.CSVPerformanceReporter')
 			optionsDict['summaryfile'] = self.expandProperties(optionsDict.get('summaryfile', ''), default=None, name='performance-reporter summaryfile')
 			results.append( (cls, optionsDict) )
 		
@@ -474,6 +474,7 @@ class _XMLProjectParser(object):
 					tag.getAttribute("value") or '\n'.join(n.data for n in tag.childNodes 
 							if (n.nodeType in {n.TEXT_NODE,n.CDATA_SECTION_NODE}) and n.data),
 					default=tag, name=name)
+			
 		classname = optionsDict.pop('classname', defaultClass)
 		if not classname: raise UserError('Missing require attribute "classname=" for <%s>'%node.tagName)
 		mod = optionsDict.pop('module', '.'.join(classname.split('.')[:-1]))

--- a/pysys/constants.py
+++ b/pysys/constants.py
@@ -264,6 +264,8 @@ LOG_PASSES = 'passed'
 LOG_SKIPS = 'skipped'
 LOG_DIFF_ADDED = 'diff+'
 LOG_DIFF_REMOVED = 'diff-'
+LOG_PERF_BETTER = 'performancebetter'
+LOG_PERF_WORSE = 'performanceworse'
 LOG_END = 'end'
 
 class PrintLogs(Enum):

--- a/pysys/perf/__init__.py
+++ b/pysys/perf/__init__.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# PySys System Test Framework, Copyright (C) 2006-2022 M.B. Grieve
+# PySys System Test Framework, Copyright (C) 2022 M.B. Grieve
 
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -15,29 +15,10 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-"""
-Old module for performance reporter - deprecated in favour of `pysys.perf`.
 
-Deprecated in PySys v2.1. 
 
 """
+Performance reporters are configurable plugins responsible for storing or displaying performance result numbers. 
+"""
 
-import collections, threading, time, math, sys, os
-import io
-import logging
-
-if __name__ == "__main__":
-	sys.path.append(os.path.dirname( __file__)+'/../..')
-
-from pysys.constants import *
-from pysys.utils.logutils import BaseLogFormatter
-from pysys.utils.fileutils import mkdir, toLongPathSafe
-from pysys.utils.pycompat import *
-
-from pysys.perf.perfreportstool import perfReportsToolMain
-
-# For backwards compatibility where modules are importing this
-from pysys.perf.reporters import *#CSVPerformanceReporter
-
-if __name__ == "__main__":
-	perfReportsToolMain(sys.argv[1:])
+__all__ = ['api', 'reporters']

--- a/pysys/perf/__init__.py
+++ b/pysys/perf/__init__.py
@@ -19,6 +19,8 @@
 
 """
 Performance reporters are configurable plugins responsible for storing or displaying performance result numbers. 
+
+They are invoked by `pysys.basetest.BaseTest.reportPerformanceResult`. 
 """
 
 __all__ = ['api', 'reporters']

--- a/pysys/perf/api.py
+++ b/pysys/perf/api.py
@@ -1,0 +1,471 @@
+#!/usr/bin/env python
+# PySys System Test Framework, Copyright (C) 2006-2022 M.B. Grieve
+
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+"""
+Performance number reporting classes, used by `pysys.basetest.BaseTest.reportPerformanceResult`. 
+
+Some reporter classes are provided in the box, and the `BasePerformanceReporter` class can be used to create more. 
+"""
+
+import collections, threading, time, math, sys, os
+import io
+import logging
+import json
+import glob
+
+from pysys.constants import *
+from pysys.utils.fileutils import mkdir, toLongPathSafe
+from pysys.utils.pycompat import *
+
+log = logging.getLogger('pysys.perfreporter')
+
+class PerformanceUnit(object):
+	"""Class which identifies the unit in which a performance result is measured.
+	
+	Every unit encodes whether big numbers are better or worse (which can be used 
+	to calculate the improvement or regression when results are compared), e.g. 
+	better for throughput numbers, worse for time taken or latency numbers. 
+	
+	For consistency, we recommend using the pre-defined units where possible. 
+	For throughput numbers or rates, that means using PER_SECOND. For latency 
+	measurements that means using SECONDS if long time periods of several 
+	seconds are expected, or NANO_SECONDS (=10**-9 seconds) if sub-second 
+	time periods are expected (since humans generally find numbers such as 
+	1,234,000 ns easier to skim-read and compare than fractional numbers like 
+	0.001234).
+
+	"""
+	def __init__(self, name, biggerIsBetter):
+		assert biggerIsBetter in [False, True], biggerIsBetter
+		self.name = name.strip()
+		assert self.name
+		self.biggerIsBetter = biggerIsBetter
+
+	def __str__(self):
+		return self.name
+
+PerformanceUnit.SECONDS = PerformanceUnit('s', False)
+PerformanceUnit.NANO_SECONDS = PerformanceUnit('ns', False) # 10**-9 seconds
+PerformanceUnit.PER_SECOND = PerformanceUnit('/s', True)
+
+class BasePerformanceReporter:
+	"""API base class for creating a reporter that handles or stores performance results for later analysis.
+	
+	Each performance result consists of a value, a result key (which must 
+	be unique across all test cases and modes, and also stable across different 
+	runs), and a unit (which also encodes whether bigger values are better or worse). 
+	Each test can report any number of performance results. 
+	
+	Performance reporter implementations are required to be thread-safe.
+	 
+	Project configuration of performance reporters is through the PySys project XML file using the 
+	``<performance-reporter>`` tag. Multiple reporters may be configured and their individual properties set through the 
+	nested ``<property>`` tag or XML attributes. Properties are set as Python attributes on the instance just after 
+	construction, with automatic conversion of type to match the default value if specified as a static attribute on the 
+	class. 
+	
+	If no reporters are explicitly configured, default reporters will be added. 
+
+	:ivar pysys.config.project.Project project: The project configuration instance.
+	
+	:ivar str testoutdir: The output directory used for this test run 
+		(equal to `runner.outsubdir`), an identifying string which often contains 
+		the platform, or when there are multiple test runs on the same machine 
+		may be used to distinguish between them. This is usually a relative path 
+		but may be an absolute path. 
+		
+	:ivar runner: A reference to the runner. 
+	
+	.. version added:: 2.1
+	"""
+	
+	def __init__(self, project, summaryfile, testoutdir, runner, **kwargs):
+		self.runner = runner
+		assert not kwargs, kwargs.keys() # **kwargs allows constructor to be extended in future if needed; give error if any unexpected args are passed
+		
+		self.testoutdir = os.path.basename(testoutdir)
+		self.summaryfile = summaryfile
+		self.project = project
+		self.hostname = HOSTNAME.lower().split('.')[0]
+		if self.runner is not None: # just in case we're constructing it for standalone execution in the compare script
+			self.runStartTime = self.runner.startTime
+		
+		self._lock = threading.RLock()
+		
+		# anything listed here can be passed using just a string literal
+		self.unitAliases = {
+			's':PerformanceUnit.SECONDS, 
+			'ns':PerformanceUnit.NANO_SECONDS, 
+			'/s': PerformanceUnit.PER_SECOND
+			}
+			
+	def setup(self, **kwargs):
+		"""
+		Called before any tests begin to prepare the performance writer for use, once the runner is setup, and any project 
+		configuration properties for this performance reporter have been assigned to this instance. 
+		
+		Usually there is no reason to override the constructor, and any initialization can be done in this method. 
+		
+		.. version added:: 2.1
+		"""
+		pass
+		
+	def getRunDetails(self, testobj=None, **kwargs):
+		"""Return an dictionary of information about this test run (e.g. hostname, start time, etc).
+		
+		Overriding this method is discouraged; customization of the run details should usually be performed by changing 
+		the ``runner.runDetails`` dictionary from the `pysys.baserunner.BaseRunner.setup()` method. 
+
+		:param testobj: the test case instance registering the value
+
+		.. versionchanged:: 2.0 Added testobj parameter, for advanced cases where you want to 
+			to provide different ``runDetails`` based on some feature of the test object or mode. 
+		
+		"""
+		return collections.OrderedDict(self.runner.runDetails)
+	
+	@staticmethod
+	def valueToDisplayString(value):
+		"""Pretty-print an integer or float value to a moderate number of significant figures.
+
+		The method additionally adds a "," grouping for large numbers.
+		
+		Subclasses may customize this if desired, including by reimplementing as a non-static method. 
+
+		:param value: the value to be displayed, which must be a numeric type. 
+
+		"""
+		if value > 1000:
+			return '{0:,}'.format(int(value))
+		else:
+			valtostr = '%0.4g' % value
+			if 'e' in valtostr: valtostr = '%f'%value
+			return valtostr
+
+	def getRunSummaryFile(self, testobj, **kwargs):
+		"""Return the fully substituted location of the file to which summary performance results will be written.
+
+		This may include the following substitutions: ``@OUTDIR@`` (=${outDirName}, the basename of the output directory for this run,
+		e.g. "linux"), ``@HOSTNAME@``, ``@DATE@``, ``@TIME@``, and ``@TESTID@``. The default is given by `DEFAULT_SUMMARY_FILE`. 
+		If the specified file does not exist it will be created; it is possible to use multiple summary files from the same
+		run. The path will be resolved relative to the pysys project root directory unless an absolute path is specified.
+
+		:param testobj: the test case instance registering the value
+
+		"""
+		summaryfile = self.summaryfile or self.summaryFile or self.DEFAULT_SUMMARY_FILE
+		
+		# properties are already expanded if set in project config, but needs doing explicitly in case default value was used
+		summaryfile = self.runner.project.expandProperties(summaryfile)
+		
+		summaryfile = summaryfile\
+			.replace('@OUTDIR@', os.path.basename(self.testoutdir)) \
+			.replace('@HOSTNAME@', self.hostname) \
+			.replace('@DATE@', time.strftime('%Y-%m-%d', time.localtime(self.runStartTime))) \
+			.replace('@TIME@', time.strftime('%H.%M.%S', time.localtime(self.runStartTime))) \
+			.replace('@TESTID@', testobj.descriptor.id)
+		
+		assert summaryfile, repr(getRunSummaryFile) # must not be empty
+		summaryfile = os.path.normpath(os.path.join(self.runner.output+'/..', summaryfile))
+		return summaryfile
+
+	def reportResult(self, testobj, value, resultKey, unit, toleranceStdDevs=None, resultDetails=None):
+		"""Report a performance result, with an associated unique key that identifies it.
+
+		:param testobj: the test case instance registering the value. Use ``testobj.descriptor.id`` to get the ``testId``. 
+		:param int|float value: the value to be reported. This may be an int or a float. 
+		:param str resultKey: a unique string that fully identifies what was measured.
+		:param PerformanceUnit unit: identifies the unit the value is measured in.
+		:param float toleranceStdDevs: indicates how many standard deviations away from the mean for a regression.
+		:param dict[str,obj] resultDetails:  A dictionary of detailed information that should be recorded together with the result.
+
+		"""
+		pass
+		
+
+	def cleanup(self):
+		"""Called when PySys has finished executing tests.
+		
+		This is where any file footer and other I/O finalization can be written to the end of performance log files, and 
+		is also a good time to do any required aggregation, printing of summaries or artifact publishing. 
+		"""
+		pass
+	
+	@staticmethod
+	def tryDeserializePerformanceFile(self, path):
+		"""
+		Advanced method which allows performance reporters to deserialize the files they write to allow them to be used 
+		as comparison baselines. 
+		
+		Most reporters do not need to worry about this method. 
+		
+		If you do implement it, return an instance of PerformanceRunData, or None if you do not support this file type, for 
+		example because the extension does not match. It is best to declare this as a static method if possible. 
+		
+		:rtype: PerformanceRunData
+		"""
+		return None
+
+class PerformanceRunData:
+	"""
+	Holds performance data for a single test run, consistenting of runDetails and a list of performance results covering 
+	one or more cycles. 
+	
+	:ivar str name: The name, typically a filename. 
+	
+	:ivar dict[str,str] ~.runDetails: A dictionary containing (string key, string value) information about the whole test 
+		run, for example operating system and hostname.
+	
+	:ivar list[dict] ~.results: A list where each item is a dictionary containing information about a given result. 
+		The current keys are: resultKey, testId, value, unit, biggerIsBetter, toleranceStdDevs, samples, stdDev, 
+		resultDetails. 
+
+	"""
+	def __init__(self, name, runDetails, results):
+		self.name = name
+		self.runDetails = runDetails
+		self.results = results
+
+	def __maybequote(self, s):
+		return '"%s"' % s if isstring(s) else s
+	def __str__(self):
+		return 'PerformanceRunData< %d results; runDetails: %s>'%(len(self.results), ', '.join([('%s=%s'%(k, self.__maybequote(self.runDetails[k]))) for k in self.runDetails]))
+	def __repr__(self):
+		return 'PerformanceRunData<runDetails: %s%s\n>'%(', '.join([('%s="%s"'%(k, self.runDetails[k])) for k in self.runDetails]),
+			''.join([('\n - %s'%(', '.join([('%s=%s'%(k, self.__maybequote(r.get(k, r.get('resultDetails',{}).get(k,None))))) for k in list(r.keys())+list(r.get('resultDetails',{}).keys()) if k!='resultDetails']))) for r in self.results]))
+
+	@staticmethod
+	def aggregate(runs):
+		"""Aggregate a list of multiple runs and/or cycles into a single performance run data object with a single 
+		entry for each unique resultKey with the value given as a mean of all the observed samples.
+
+		:param list[PerformanceRunData] files: the list of run objects to aggregate.
+
+		"""
+		if isinstance(runs, PerformanceRunData): runs = [runs]
+		
+		details = {} # values are lists of unique run detail values from input files
+		results = {}
+		for f in runs:
+			if not f.results: continue # don't even include the rundetails if there are no results
+			for r in f.results:
+				if r['resultKey'] not in results:
+					results[r['resultKey']] = collections.OrderedDict(r)
+					# make it a deep copy
+					results[r['resultKey']]['resultDetails'] = collections.OrderedDict( results[r['resultKey']].get('resultDetails', {}))
+				else:
+					e = results[r['resultKey']] # existing result which we will merge the new data into
+
+					# calculate new mean and stddev
+					combinedmean = (e['value']*e['samples'] + r['value']*r['samples']) / (e['samples']+r['samples'])
+
+					# nb: do this carefully to avoid subtracting large numbers from each other
+					# also we calculate the SAMPLE standard deviation (i.e. using the bessel-corrected unbiased estimate)
+					e['stdDev'] = math.sqrt(
+						((e['samples']-1)*(e['stdDev']**2)
+						 +(r['samples']-1)*(r['stdDev']**2)
+						 +e['samples']*( (e['value']-combinedmean) ** 2 )
+						 +r['samples']*( (r['value']-combinedmean) ** 2 )
+						 ) / (e['samples'] + r['samples'] - 1)
+					)
+					e['value'] = combinedmean
+					e['samples'] += r['samples']
+					e['resultDetails'] = r.get('resultDetails', {}) # just use latest; shouldn't vary
+
+			for k in f.runDetails:
+				if k not in details:
+					details[k] = []
+				if f.runDetails[k] not in details[k]:
+					details[k].append(f.runDetails[k])
+
+		return PerformanceRunData(
+			', '.join(run.name or '?' for run in runs),
+			{k: '; '.join(sorted(details[k])) for k in details},
+			sorted(list(results.values()), key=lambda r: r['resultKey'])
+			)
+			
+		
+class CSVPerformanceFile(PerformanceRunData):
+	"""Holds performance data for a single test run in a CSV performance file.
+
+	If this file contains aggregated results the number of "samples" may be greater than 1 and the "value"
+	will specify the mean result.
+
+	:ivar dict[str,obj] ~.runDetails: A dictionary containing (string key, string value) information about the whole test run.
+	
+	:ivar list[dict] ~.results: A list where each item is a dictionary containing information about a given result, 
+		containing values for each of the keys in L{COLUMNS}, for example 'resultKey', 'value', etc. 
+		
+	:ivar str ~.RUN_DETAILS: The constant prefix identifying information about the whole test run
+	
+	:ivar str ~.RESULT_DETAILS: The constant prefix identifying detailed information about a given result
+	
+	:ivar list[str] ~.COLUMNS: Constant list of the columns in the performance output
+
+	:param str contents: A string containing the contents of the file to be parsed (can be empty)
+	:rtype: CSVPerformanceFile
+	"""
+	COLUMNS = ['resultKey','testId','value','unit','biggerIsBetter','toleranceStdDevs','samples','stdDev']
+	RUN_DETAILS = '#runDetails:#'
+	RESULT_DETAILS = '#resultDetails:#'
+
+	@staticmethod
+	def aggregate(files):
+		"""Aggregate a list of performance file objects into a single CSVPerformanceFile object.
+
+		Takes a list of one or more CSVPerformanceFile objects and returns a single aggregated
+		CSVPerformanceFile with a single row for each resultKey (with the "value" set to the
+		mean if there are multiple results with that key, and the stdDev also set appropriately).
+
+		This method is now deprecated in favour of `PerformanceRunData.aggregate`. 
+
+		:param list[CSVPerformanceFile] files: the list of performance file objects to aggregate.
+
+		"""
+		if isinstance(files, CSVPerformanceFile): files = [files]
+		
+		agg = PerformanceRunData.aggregate([f for f in files])
+		result = CSVPerformanceFile('', name=agg.name)
+		result.results = agg.results
+		result.runDetails = agg.runDetails
+		return result
+
+	@staticmethod
+	def load(src):
+		"""
+		Read the runDetails and results from the specified .csv file on disk.
+		
+		:str src: The path to read. 
+		:returns: A new `CSVPerformanceFile` instance. 
+		
+		.. versionadded:: 2.1
+		"""
+		with io.open(toLongPathSafe(src), 'r', encoding='utf-8') as f:
+			return CSVPerformanceFile(f.read(), name=src)
+				
+	def dump(self, dest):
+		"""
+		Dump the runDetails and results from this object to a CSV at the specified location. 
+		
+		Any existing file is overwritten. 
+		
+		:str dest: The destination path or file handle to write to. 
+		
+		.. versionadded:: 2.1
+		"""
+		if isinstance(dest, str):
+			with io.open(toLongPathSafe(dest), 'w', encoding='utf-8') as f:
+				return self.dump(f)
+				
+		dest.write(self.makeCSVHeaderLine(self.runDetails))
+		for v in self.results:
+			dest.write(self.toCSVLine(v)+'\n')
+
+	@staticmethod 
+	def makeCSVHeaderLine(runDetails):
+		return '# '+CSVPerformanceFile.toCSVLine(CSVPerformanceFile.COLUMNS+[CSVPerformanceFile.RUN_DETAILS, runDetails])+'\n'
+
+	@staticmethod
+	def toCSVLine(values):
+		"""Convert a list or dictionary of input values into a CSV string.
+
+		Note that no new line character is return in the CSV string. The input values can either be
+		a list (any nested dictionaries are expanded into KEY=VALUE entries), or a dictionary (or OrderedDict)
+		whose keys will be added in the same order as COLUMNS.
+
+		:param values: the input list or dictionary
+
+		"""
+		if isinstance(values, list):
+			items = []
+			for v in values:
+				if isinstance(v, dict):
+					for k in v:
+						items.append('%s=%s'%(k.replace('=','-').strip(), str(v[k]).replace('=','-').strip()))
+				else:
+					items.append(v)
+			
+			return ','.join([v.replace(',', ';').replace('"', '_').strip() for v in items])
+
+		elif isinstance(values, dict):
+			l = []
+			for k in CSVPerformanceFile.COLUMNS:
+				l.append(str(values.get(k,'')))
+			if values.get('resultDetails', None):
+				l.append(CSVPerformanceFile.RESULT_DETAILS)
+				for k in values['resultDetails']:
+					l.append('%s=%s'%(k, values['resultDetails'][k]))
+			return CSVPerformanceFile.toCSVLine(l)
+
+		else:
+			raise Exception('Unsupported input type: %s'%values.__class__.__name__)
+		
+	def __init__(self, contents, name=None):
+		super().__init__(name, None, [])
+		header = None
+		self.results = []
+		self.runDetails = None
+		for l in contents.split('\n'):
+			l = l.strip()
+			if not l: continue
+			try:
+				if not header:
+					header = []
+					assert l.startswith('#')
+					for h in l.strip().split(','):
+						h = h.strip()
+						if h== self.RUN_DETAILS:
+							self.runDetails = collections.OrderedDict()
+						elif self.runDetails != None:
+							h = h.split('=', 1)
+							self.runDetails[h[0].strip()] = h[1].strip()
+						else:
+							h = h.strip('#').strip()
+							if h: header.append(h)
+				elif l.startswith('#'): continue
+				else:
+					row = l.split(',')
+					r = collections.OrderedDict()
+					for i in range(len(header)):
+						if i >= len(row):
+							raise Exception('Missing value for column "%s"'%header[i])
+						else:
+							val = row[i].strip()
+							if header[i] in ['value', 'toleranceStdDevs', 'stdDev']:
+								val = float(val or '0')
+							elif header[i] in ['samples']:
+								val = int(val  or '0')
+							elif header[i] in ['biggerIsBetter']:
+								val = True if val.lower()=='true' else False
+							r[header[i]] = val
+					resultDetails = None
+					result = collections.OrderedDict()
+					for i in range(0, len(row)):
+						row[i] = row[i].strip()
+						if row[i] == self.RESULT_DETAILS:
+							resultDetails = collections.OrderedDict()
+						elif resultDetails != None:
+							d = row[i].split('=',1)
+							resultDetails[d[0].strip()] = d[1].strip()
+					
+					if resultDetails == None: resultDetails = collections.OrderedDict()
+					r['resultDetails'] = resultDetails
+					self.results.append(r)
+			except Exception as e:
+				raise Exception('Cannot parse performance line - %s (%s): "%s"'%(e, e.__class__.__name__, l))
+		
+		if self.runDetails == None: self.runDetails = collections.OrderedDict()

--- a/pysys/perf/api.py
+++ b/pysys/perf/api.py
@@ -123,7 +123,7 @@ class BasePerformanceReporter:
 		
 		.. version added:: 2.1
 		"""
-		pass
+		pass # pragma: no cover
 		
 	def getRunDetails(self, testobj=None, **kwargs):
 		"""Return an dictionary of information about this test run (e.g. hostname, start time, etc).
@@ -199,7 +199,7 @@ class BasePerformanceReporter:
 		:param dict[str,obj] resultDetails:  A dictionary of detailed information that should be recorded together with the result.
 
 		"""
-		pass
+		pass # pragma: no cover
 		
 
 	def cleanup(self):
@@ -208,7 +208,7 @@ class BasePerformanceReporter:
 		This is where any file footer and other I/O finalization can be written to the end of performance log files, and 
 		is also a good time to do any required aggregation, printing of summaries or artifact publishing. 
 		"""
-		pass
+		pass # pragma: no cover
 	
 	@staticmethod
 	def tryDeserializePerformanceFile(self, path):
@@ -223,7 +223,7 @@ class BasePerformanceReporter:
 		
 		:rtype: PerformanceRunData
 		"""
-		return None
+		return None # pragma: no cover
 
 class PerformanceRunData:
 	"""
@@ -417,7 +417,7 @@ class CSVPerformanceFile(PerformanceRunData):
 			return CSVPerformanceFile.toCSVLine(l)
 
 		else:
-			raise Exception('Unsupported input type: %s'%values.__class__.__name__)
+			raise Exception('Unsupported input type: %s'%values.__class__.__name__) # pragma: no cover
 		
 	def __init__(self, contents, name=None):
 		super().__init__(name, None, [])
@@ -447,7 +447,7 @@ class CSVPerformanceFile(PerformanceRunData):
 					r = collections.OrderedDict()
 					for i in range(len(header)):
 						if i >= len(row):
-							raise Exception('Missing value for column "%s"'%header[i])
+							raise Exception('Missing value for column "%s"'%header[i]) # pragma: no cover
 						else:
 							val = row[i].strip()
 							if header[i] in ['value', 'toleranceStdDevs', 'stdDev']:
@@ -470,7 +470,7 @@ class CSVPerformanceFile(PerformanceRunData):
 					if resultDetails == None: resultDetails = collections.OrderedDict()
 					r['resultDetails'] = resultDetails
 					self.results.append(r)
-			except Exception as e:
+			except Exception as e: # pragma: no cover
 				raise Exception('Cannot parse performance line - %s (%s): "%s"'%(e, e.__class__.__name__, l))
 		
 		if self.runDetails == None: self.runDetails = collections.OrderedDict()

--- a/pysys/perf/perfreportstool.py
+++ b/pysys/perf/perfreportstool.py
@@ -161,11 +161,11 @@ class PerformanceComparisonGenerator:
 
 		out('')
 		out('Comparison results:')
-		out('  where fromRun->toRun format is: (%improvement) = (speedup ratio) = (sigmas/stdDevs where change above +/- 2.0 gives 95% probability it\'s significant)')
+		out('  where fromRun->toRun format is: (%improvement) = (speedup ratio) = (sigmas/stdDevs where change above +/- 2.0 gives 95% probability it\'s significant; only significant results are colored)')
 		out('')
 		ComparisonData = collections.namedtuple('ComparisonData', [
 			'comparisonPercent', #%improvement
-			'comparisonSigmas', # improvements as a multiple of stddec
+			'comparisonSigmas',  #improvements as a multiple of stddev
 			'ratio', # speedup ratio of from->to, how much faster we are now
 			'rfrom', # the "from" result value
 			'rto',   # the "to"   result value
@@ -214,6 +214,7 @@ class PerformanceComparisonGenerator:
 					# assuming a normal distribution, 1.0 or more gives 68% confidence of 
 					# a real difference, and 2.0 or more gives 95%. 
 					comparisonSigmas = sign*((ratio-1)/relStdDev) if relStdDev else None
+					# = (new-old)/stddev
 
 					# but +/- isn't relevant when displaying the ratio; we want ratios >1 to always be a good thing, so use reciprocal here
 					if not k.biggerIsBetter: ratio = 1.0/ratio
@@ -248,7 +249,8 @@ class PerformanceComparisonGenerator:
 			
 			r = files[-1].keyedResults[k]
 			out(' '+f"Mean from this run = {self.valueToDisplayString(r['value'])} {r['unit']}"+
-							('' if r['samples']==1 or ['value'] == 0 else f" with stdDev={self.valueToDisplayString(r['stdDev'])} ({100.0*r['stdDev']/r['value']:0.1f}% of mean)"),
+							('' if r['samples']==1 or ['value'] == 0 else f" with stdDev={self.valueToDisplayString(r['stdDev'])} ({100.0*r['stdDev']/r['value']:0.1f}% of mean)")+
+							('' if not r.get('toleranceStdDevs') else f"; configured toleranceStdDevs={self.valueToDisplayString(r['toleranceStdDevs'])}"),
 					)
 
 			i = 0

--- a/pysys/perf/perfreportstool.py
+++ b/pysys/perf/perfreportstool.py
@@ -155,7 +155,7 @@ class PerformanceComparisonGenerator:
 				len(p.results), 
 				float( sum([r['samples'] for r in p.results])) / len(p.results),
 				'' if p.comparisonLabel != p.runDetails.get('outDirName')
-					else f' from {p.name}'
+					else f' from {p.name if not os.path.abspath(p.name) else os.path.relpath(p.name)}'
 				))
 			out('     %s'%', '.join([formatRunDetails(k, p.runDetails[k]) for k in p.runDetails if k not in commonRunDetails]))
 

--- a/pysys/perf/perfreportstool.py
+++ b/pysys/perf/perfreportstool.py
@@ -1,0 +1,363 @@
+#!/usr/bin/env python
+# PySys System Test Framework, Copyright (C) 2006-2022 M.B. Grieve
+
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+"""
+Non-public module providing a command line for working with performance reports. 
+
+:meta private: Not public API may change at any time. 
+
+"""
+
+import collections, threading, time, math, sys, os
+import io
+import logging
+import json
+import glob
+
+if __name__ == "__main__":
+	sys.path.append(os.path.dirname( __file__)+'/../..')
+
+from pysys.constants import *
+from pysys.utils.logutils import BaseLogFormatter
+from pysys.utils.fileutils import mkdir, toLongPathSafe
+from pysys.utils.pycompat import *
+from pysys.utils.logutils import ColorLogFormatter, stdoutPrint
+
+from pysys.perf.api import *
+from pysys.perf.reporters import *
+
+log = logging.getLogger('pysys.perfreporter')
+
+class PerformanceComparisonGenerator:
+	"""Internal helper class for comparing multiple .csv or json performance files and printing the differences. 
+
+	:meta private: Not public API may change at any time. 
+	.. versionadded:: 2.1
+
+	"""
+
+	BASELINES_ENV_VAR = PrintSummaryPerformanceReporter.BASELINES_ENV_VAR
+
+	def __init__(self, reporters): 
+		self.reporters = reporters # list of perf reporter instances (or for standalone invocation, classes); must be at least one
+		
+			# - with the static tryDeserializePerformanceFile method on them
+			
+		# We'd like to delegate to the first runner. Assuming it's a static method is probably reasonable. Could break if user subclass redefines as non-static
+		self.valueToDisplayString = reporters[0].valueToDisplayString
+
+	def loadFiles(self, baselineBaseDir, paths):
+		# return a list PerformanceRunData for each path in the specified list
+		
+		configuredBaselines = os.getenv(self.BASELINES_ENV_VAR)
+		if not paths:
+			return None
+
+		baselines = []
+		for b in paths:
+			b = b.strip()
+			if not b: continue
+			
+			# if not abs, take paths as relative to testRootDir. Easier to work with the cwd which is constantly changing
+			b = os.path.join(baselineBaseDir, b)
+			
+			if os.path.isfile(b): 
+				baselines.append(b)
+			else:
+				globresults = sorted(glob.glob(b, recursive=True))
+				if not globresults: raise Exception('Cannot find any paths matching '+self.BASELINES_ENV_VAR+' expression: %s'%b)
+				baselines.extend(globresults)
+		baselineData = {}
+		for b in baselines:
+			if os.path.isdir(b): raise Exception(self.BASELINES_ENV_VAR+' may contain "*" or "**" glob expressions but not directories: %s'%b)
+			x = None
+			for r in self.reporters:
+				x = r.tryDeserializePerformanceFile(b)
+				if x: break
+			if x:
+				baselineData[b] = x
+			else:
+				raise Exception('Failed to find a reporter that can deserialize performance files of this type: %s'%b)
+
+		baselineData = [PerformanceRunData.aggregate(b) for b in baselineData.values()]
+		return baselineData
+		
+	def logComparisons(self, comparisonFiles, sortby=None, printmethod=stdoutPrint):
+		# comparisonFiles are a list of PerformanceRunData instances
+		
+		# NB: this method implementation mutates the passed in comparisonFiles
+		
+		sortby = sortby or os.getenv('PYSYS_PERFORMANCE_SORT_BY', 'resultKey')
+		
+		files = comparisonFiles
+
+		out  = printmethod
+
+		# we may not have the project available here if running this standalone, but can still reuse the same 
+		# logic for deciding if coloring is enabled
+		colorFormatter = ColorLogFormatter({})
+		def addColor(category, s):
+			if not category: return s
+			return colorFormatter.formatArg(category, s) 
+				
+		# usually resultKey is itself the unique key, but for comparisons we also 
+		# want to include units/biggerIsBetter since if these change the 
+		# comparison would be invalidated
+		ComparisonKey = collections.namedtuple('ComparisonKey', ['resultKey', 'unit', 'biggerIsBetter'])
+
+		# iterate over each comparison item, stashing various aggregated information we need later, and printing summary info
+		for p in files:
+			p.keyedResults = {
+				ComparisonKey(resultKey=r['resultKey'], unit=r['unit'], biggerIsBetter=r['biggerIsBetter'])
+				: r for r in p.results
+			}
+
+		commonRunDetails = {}
+		for k in list(files[-1].runDetails.keys()):
+			if all([k in p.runDetails and  p.runDetails[k] == files[-1].runDetails[k] for p in files]):
+				commonRunDetails[k] = files[-1].runDetails[k]
+
+		def formatRunDetails(k, val):
+			valsplit = val.split(';')
+			if k == 'startTime' and len(valsplit)>=3:
+				val = ' .. '.join([valsplit[0].strip(), valsplit[-1].strip()])
+			else:
+				val = val.replace('; ',';')
+			return '%s=%s'%(k, addColor(LOG_TEST_DETAILS, val))
+
+		#out('Comparing performance files with these common run details: %s'% ', '.join([formatRunDetails(k, commonRunDetails[k]) for k in commonRunDetails]))
+
+		# Assign a comparison label to each; use outDirName if unique, else make something based on the filename
+		if len(set(p.runDetails.get('outDirName') for p in files)) == len(files):
+			for p in files: p.comparisonLabel = p.runDetails.get('outDirName', p.name)
+		else:
+			for p in files: p.comparisonLabel = os.path.splitext(os.path.basename(p.name))[0].replace('perf_','')
+			
+		out('Performance comparison summary between the following runs (the differing "run details" are shown):')
+			
+		for p in files:
+			out('- %s (%d result keys, %d samples/result)%s:'%(
+				addColor(LOG_TEST_DETAILS, p.comparisonLabel), 
+				len(p.results), 
+				float( sum([r['samples'] for r in p.results])) / len(p.results),
+				'' if p.comparisonLabel != p.runDetails.get('outDirName')
+					else f' from {p.name}'
+				))
+			out('     %s'%', '.join([formatRunDetails(k, p.runDetails[k]) for k in p.runDetails if k not in commonRunDetails]))
+
+		out('')
+		out('Comparison results:')
+		out('  where fromRun->toRun format is: (%improvement) = (speedup ratio) = (sigmas/stdDevs where change above +/- 2.0 gives 95% probability it\'s significant)')
+		out('')
+		ComparisonData = collections.namedtuple('ComparisonData', [
+			'comparisonPercent', #%improvement
+			'comparisonSigmas', # improvements as a multiple of stddec
+			'ratio', # speedup ratio of from->to, how much faster we are now
+			'rfrom', # the "from" result value
+			'rto',   # the "to"   result value
+			'relativeStdDevTo', # relative stdDev as a % of the "to" value, or None if only one sample (or value is 0)
+			'toleranceStdDevs', # The configured tolerance specified in this test, if any
+			])
+		
+		# now compute comparison info, comparing each path to the final one
+		comparisons = {} # ComparisonKey:[ComparisonInfo or string if not available, ...]
+		comparetoresults = files[-1].keyedResults
+		comparisonheaders = []
+		for p in files[:-1]:
+			if len(files)>2:
+				comparisonheaders.append('%s->%s'%(p.comparisonLabel, files[-1].comparisonLabel))
+			
+			keyedResults = p.keyedResults
+			for k in comparetoresults:
+				c = comparisons.setdefault(k, [])
+				if k not in keyedResults:
+					c.append('Compare from value is missing')
+				else:
+					rfrom = keyedResults[k]
+					rto = comparetoresults[k]
+					# avoid div by zero errors; results are nonsensical anyway if either is zero
+					if rfrom['value'] == 0: 
+						c.append('Compare from value is zero')
+						continue
+					if rto['value'] == 0: 
+						c.append('Compare to value is zero')
+						continue
+
+					
+					# frequently at least one of these will have only one sample so 
+					# not much point doing a statistically accurate stddev estimate; so just 
+					# take whichever is bigger (which neatly ignores any that are zero due
+					# to only one sample)
+					relStdDev = max(abs(rfrom['stdDev']/rfrom['value']), abs(rto['stdDev']/rto['value']))
+
+					# how many times faster are we now
+					ratio = rto['value']/rfrom['value'] # initially, we ignore biggerIsBetter in the ratio calculation...
+					
+					# use a + or - sign to indicate improvement vs regression in the % (rather than a reciprocal which is harder to understand)
+					sign = 1.0 if k.biggerIsBetter else -1.0
+					comparisonPercent = 100.0*(ratio - 1)*sign
+					
+					# assuming a normal distribution, 1.0 or more gives 68% confidence of 
+					# a real difference, and 2.0 or more gives 95%. 
+					comparisonSigmas = sign*((ratio-1)/relStdDev) if relStdDev else None
+
+					# but +/- isn't relevant when displaying the ratio; we want ratios >1 to always be a good thing, so use reciprocal here
+					if not k.biggerIsBetter: ratio = 1.0/ratio
+					
+					c.append(ComparisonData(
+						comparisonPercent=comparisonPercent, 
+						comparisonSigmas=comparisonSigmas,
+						ratio=ratio,
+						rfrom=rfrom['value'], 
+						rto=rto['value'],
+						relativeStdDevTo=100.0*rto['stdDev']/rto['value'] if rto['samples'] > 0 and rto['value']!=0 else None,
+						toleranceStdDevs=files[-1].keyedResults[k].get('toleranceStdDevs', 0.0),
+					))
+
+		if comparisonheaders:
+			headerpad = max([len(h) for h in comparisonheaders])
+			comparisonheaders = [('%'+str(headerpad+1)+'s')%(h+':') for h in ([files[-1].comparisonLabel]+comparisonheaders)]
+
+		def getComparisonKey(k):
+			if sortby == 'resultKey': return k
+			if sortby == 'testId': return (allresultinfo[k]['testId'], k)
+			# sort with regressions at the bottom, so they're more prominent
+			if sortby == 'comparison%': return [
+					(-1*c.comparisonPercent) if hasattr(c, 'comparisonPercent') else -10000000.0
+					for c in comparisons[k]]+[k]
+			raise Exception(f'Invalid sortby key "{sortby}"; valid values are: resultKey, testId, comparison%')
+
+		sortedkeys = sorted(comparisons.keys(), key=getComparisonKey)
+		
+		for k in sortedkeys:
+			out('%s from %s'%(colorFormatter.formatArg(LOG_TEST_PERFORMANCE, k.resultKey), files[-1].keyedResults[k]['testId']))
+			
+			r = files[-1].keyedResults[k]
+			out(' '+f"Mean from this run = {self.valueToDisplayString(r['value'])} {r['unit']}"+
+							('' if r['samples']==1 or ['value'] == 0 else f" with stdDev={self.valueToDisplayString(r['stdDev'])} ({100.0*r['stdDev']/r['value']:0.1f}% of mean)"),
+					)
+
+			i = 0
+			for c in comparisons[k]:
+				i+=1
+				prefix = ('%s '%comparisonheaders[i]) if comparisonheaders else ''
+				if not hasattr(c, 'comparisonPercent'):
+					# strings for error messages
+					out('  '+prefix+c)
+					continue
+				
+				out('  '+prefix+self.formatResultComparison(c, addColor=addColor))
+			out('')
+
+	@staticmethod
+	def addPlus(s):
+		if not s.startswith('-'): return '+'+s
+		return s
+
+	def formatResultComparison(self, comparisonData, addColor, **kwargs):
+		# addColor function is passed like this just for simplicity, would be more elegant if this was public API
+		c = comparisonData
+		
+		# don't color for tiny deviations
+		if c.comparisonSigmas != None:
+			significantresult = abs(c.comparisonSigmas) >= (c.toleranceStdDevs or 2.0)
+		else:
+			significantresult = abs(c.comparisonPercent) >= 10
+		category = None
+		if significantresult:
+			category = LOG_PERF_BETTER if c.comparisonPercent > 0 else LOG_PERF_WORSE
+		
+		if c.comparisonSigmas is None:
+			sigmas = ''
+		else:
+			sigmas = ' = %s sigmas'%addColor(category, self.addPlus('%0.1f'%c.comparisonSigmas))
+		
+		result = addColor(category, '%6s'%(self.addPlus('%0.1f'%c.comparisonPercent)+'%'))
+
+		result += ' = '+addColor(category, self.valueToDisplayString(c.ratio)+'x')+' speedup'
+
+		result += sigmas
+		
+		return result
+
+
+
+def perfReportsToolMain(args):
+	USAGE = """
+perfreportstool.py aggregate PATH1 PATH2... > aggregated.csv
+perfreportstool.py compare PATH_GLOB1 PATH_GLOB2...
+
+where PATH is a .csv file or directory of .csv files 
+      GLOB_PATH is a path to a file or files, optionally containing by * and ** globs
+
+The aggregate command combines the specifies CSVfile(s) to form a single file 
+with one row for each resultKey, with the 'value' equal to the mean of all 
+values for that resultKey and the 'stdDev' updated with the standard deviation. 
+This can also be used with one or more .csv file to aggregate results from multiple 
+cycles. 
+
+The compare command prints a comparison from each listed performance file to the final one in the list.
+Note that the format of the output may change at any time, and it is not intended for machine parsing. 
+
+"""
+	# could later add support for automatically comparing files
+	if '-h' in sys.argv or '--help' in args or len(args) <2 or args[0] not in ['aggregate', 'compare']:
+		sys.stderr.write(USAGE)
+		sys.exit(1)
+	
+	cmd = args[0]
+	
+	# send log output to stderr to avoid interfering with output we might be redirecting to a file	
+	logging.basicConfig(format='%(levelname)s: %(message)s', stream=sys.stderr, level=getattr(logging, os.getenv('PYSYS_LOG_LEVEL', 'INFO').upper()))
+	
+	if cmd == 'aggregate':
+		paths = []
+		for p in args[1:]:
+			if os.path.isfile(p):
+				paths.append(p)
+			elif os.path.isdir(p):
+				for (dirpath, dirnames, filenames) in os.walk(p):
+					for f in sorted(filenames):
+						if f.endswith('.csv'):
+							paths.append(dirpath+'/'+f)
+			else:
+				raise Exception('Cannot find file: %s'%p)
+		
+		if not paths:
+			raise Exception('No .csv files found')
+		files = []
+		for p in paths:
+			with io.open(toLongPathSafe(os.path.abspath(p)), encoding='utf-8') as f:
+				files.append(CSVPerformanceFile(f.read()))
+
+		f = CSVPerformanceFile.aggregate(files)
+		f.dump(sys.stdout)
+	elif cmd == 'compare':
+		paths = args[1:]
+		from pysys.config.project import Project
+
+		project = Project.findAndLoadProject()
+		# Can't easily get these classes from project without replicating the logic to instantiate them, which would 
+		# be error prone
+		performanceReporterClasses = [CSVPerformanceReporter, JSONPerformanceReporter]
+		
+		gen = PerformanceComparisonGenerator(performanceReporterClasses)
+		files = gen.loadFiles(baselineBaseDir=project.testRootDir, paths=paths)
+		gen.logComparisons(files)
+
+if __name__ == "__main__":
+	perfReportsToolMain(sys.argv[1:])

--- a/pysys/perf/perfreportstool.py
+++ b/pysys/perf/perfreportstool.py
@@ -29,7 +29,7 @@ import json
 import glob
 
 if __name__ == "__main__":
-	sys.path.append(os.path.dirname( __file__)+'/../..')
+	sys.path.append(os.path.dirname( __file__)+'/../..') # pragma: no cover
 
 from pysys.constants import *
 from pysys.utils.logutils import BaseLogFormatter
@@ -65,7 +65,7 @@ class PerformanceComparisonGenerator:
 		
 		configuredBaselines = os.getenv(self.BASELINES_ENV_VAR)
 		if not paths:
-			return None
+			return None  # pragma: no cover
 
 		baselines = []
 		for b in paths:
@@ -90,7 +90,7 @@ class PerformanceComparisonGenerator:
 				if x: break
 			if x:
 				baselineData[b] = x
-			else:
+			else:  # pragma: no cover
 				raise Exception('Failed to find a reporter that can deserialize performance files of this type: %s'%b)
 
 		baselineData = [PerformanceRunData.aggregate(b) for b in baselineData.values()]

--- a/pysys/perf/reporters.py
+++ b/pysys/perf/reporters.py
@@ -30,7 +30,6 @@ from pysys.constants import *
 from pysys.utils.logutils import BaseLogFormatter
 from pysys.utils.fileutils import mkdir, toLongPathSafe
 from pysys.utils.pycompat import *
-import pysys.perf.perfreportstool
 
 log = logging.getLogger('pysys.perfreporter')
 
@@ -142,6 +141,7 @@ class PrintSummaryPerformanceReporter(BasePerformanceReporter):
 		super().setup()
 		self.results = []
 		
+		import pysys.perf.perfreportstool
 		self.comparisonGenerator = pysys.perf.perfreportstool.PerformanceComparisonGenerator(reporters=self.runner.performanceReporters)
 		self.baselines = self.comparisonGenerator.loadFiles(
 			baselineBaseDir=self.project.testRootDir,

--- a/pysys/perf/reporters.py
+++ b/pysys/perf/reporters.py
@@ -16,9 +16,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
 """
-Performance number reporting classes, used by `pysys.basetest.BaseTest.reportPerformanceResult`. 
-
-Some reporter classes are provided in the box, and the `BasePerformanceReporter` class can be used to create more. 
+Contains the built-in reporter classes. 
 """
 
 import collections, threading, time, math, sys, os
@@ -256,6 +254,8 @@ class CSVPerformanceReporter(BasePerformanceReporter):
 		"""Return the header string to the CSV file.
 		
 		There should usually be no reason to override this method. 
+		
+		:meta private:
 		"""
 		
 		try:
@@ -294,6 +294,8 @@ class CSVPerformanceReporter(BasePerformanceReporter):
 	def formatResult(self, testobj, value, resultKey, unit, toleranceStdDevs, resultDetails):
 		"""Retrieve an object representing the specified arguments that will be passed to recordResult to be written to the performance file(s).
 
+		:meta private:
+
 		:param testobj: the test case instance registering the value
 		:param value: the value to be reported
 		:param resultKey: a unique string that fully identifies what was measured
@@ -316,6 +318,8 @@ class CSVPerformanceReporter(BasePerformanceReporter):
 
 	def recordResult(self, formatted, testobj):
 		"""Record results to the performance summary file.
+
+		:meta private:
 
 		:param formatted: the formatted string to write
 		:param testobj: object reference to the calling test

--- a/pysys/perf/reporters.py
+++ b/pysys/perf/reporters.py
@@ -274,7 +274,7 @@ class CSVPerformanceReporter(BasePerformanceReporter):
 						try:
 							perfFile = CSVPerformanceFile.load(p)
 							perfFile = CSVPerformanceFile.aggregate([perfFile])
-						except Exception as ex:
+						except Exception as ex: # pragma: no cover
 							log.exception('Failed to read and aggregate performance information for %s: '%p)
 							# Don't make it fatal, more useful to go ahead and publish it as best we can
 						else:
@@ -332,7 +332,7 @@ class CSVPerformanceReporter(BasePerformanceReporter):
 		def callGetRunHeader():
 			try:
 				return self.getRunHeader(testobj)
-			except Exception: # for pre-2.0 signature
+			except Exception: # pragma: no cover - for pre-2.0 signature 
 				return self.getRunHeader()
 		
 		if not os.path.exists(path):

--- a/pysys/perf/reporters.py
+++ b/pysys/perf/reporters.py
@@ -1,0 +1,356 @@
+#!/usr/bin/env python
+# PySys System Test Framework, Copyright (C) 2006-2021 M.B. Grieve
+
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+"""
+Performance number reporting classes, used by `pysys.basetest.BaseTest.reportPerformanceResult`. 
+
+Some reporter classes are provided in the box, and the `BasePerformanceReporter` class can be used to create more. 
+"""
+
+import collections, threading, time, math, sys, os
+import io
+import logging
+import json
+import glob
+
+from pysys.perf.api import *
+from pysys.constants import *
+from pysys.utils.logutils import BaseLogFormatter
+from pysys.utils.fileutils import mkdir, toLongPathSafe
+from pysys.utils.pycompat import *
+import pysys.perf.perfreportstool
+
+log = logging.getLogger('pysys.perfreporter')
+
+class JSONPerformanceReporter(BasePerformanceReporter):
+	"""Performance reporter which writes to a JSON file.
+	
+	After tests have run, the summary file is published with category ``JSONPerformanceReport`` 
+	using the `pysys.writer.api.ArtifactPublisher` interface. 
+
+	.. versionadded:: 2.1
+
+	The following properties can be set in the project configuration for this reporter:		
+	
+	"""
+	
+	summaryFile = ''
+	"""
+	The ``.json`` filename pattern used for the summary file(s); see `DEFAULT_SUMMARY_FILE`. 
+	"""
+
+	publishArtifactCategory = 'JSONPerformanceReport' 
+	"""
+	If specified, the output file will be published as an artifact using the specified category name. 
+	"""
+
+	DEFAULT_SUMMARY_FILE = '__pysys_performance/${outDirName}_${hostname}/perf_${startDate}_${startTime}.${outDirName}.json'
+	"""The default summary file if not overridden by the ``summaryFile=`` attribute. See `getRunSummaryFile()`. 
+	This is relative to the runner output+'/..' directory (typically testRootDir, unless ``--outdir`` is overridden).
+	"""
+
+	def setup(self, **kwargs):
+		super().setup()
+		self.__summaryFilesWritten = set()
+		
+	def reportResult(self, testobj, value, resultKey, unit, toleranceStdDevs=None, resultDetails=None):
+		path = self.getRunSummaryFile(testobj)
+		mkdir(os.path.dirname(path))
+		with self._lock:
+			alreadyexists = os.path.exists(toLongPathSafe(path))
+			with io.open(toLongPathSafe(path), 'a', encoding='utf-8') as f:
+				if not alreadyexists: 
+					testobj.log.info('Creating performance summary log file at: %s', os.path.normpath(path))
+					f.write('{"runDetails": ')
+					json.dump(self.getRunDetails(testobj), f)
+					f.write(', "results":[\n')
+				else:
+					f.write(',\n')
+					
+				json.dump({
+					'resultKey':resultKey,
+					'value':value,
+					'unit':str(unit),
+					'biggerIsBetter':unit.biggerIsBetter,
+					'samples':1,
+					'stdDev':0,
+					'toleranceStdDevs':toleranceStdDevs,
+					'testId':testobj.descriptor.id,
+					'resultDetails':resultDetails or {}
+				}, f)
+			self.__summaryFilesWritten.add(path)
+
+	def cleanup(self):
+		with self._lock:
+			if self.__summaryFilesWritten:
+				for p in sorted(list(self.__summaryFilesWritten)):
+					with io.open(toLongPathSafe(p), 'a', encoding='utf-8') as f:
+						f.write('\n]}\n')
+					
+					log.info('Performance results were written to: %s', os.path.normpath(p).replace(os.path.normpath(self.project.testRootDir), '').lstrip('/\\'))
+
+					if self.publishArtifactCategory:
+						self.runner.publishArtifact(p, self.publishArtifactCategory)
+
+	@staticmethod
+	def tryDeserializePerformanceFile(path):
+		if not path.endswith('.json'): return None
+		with io.open(toLongPathSafe(path), encoding='utf-8') as f:
+			data = json.load(f)
+			return PerformanceRunData(path, data['runDetails'], data['results'])
+
+class PrintSummaryPerformanceReporter(BasePerformanceReporter):
+	"""Performance reporter which logs a human-friendly summary of all performance results to the console at the end of 
+	the test run. 
+
+	By setting the `BASELINES_ENV_VAR` environment variable, this reporter will also print out an 
+	automatic comparison from the named baseline file(s) to the results from the current test run. 
+	This feature is very useful when comparingdifferent strategies for optimizing your application. 
+	
+	.. versionadded:: 2.1
+
+	"""
+
+	BASELINES_ENV_VAR = 'PYSYS_PERFORMANCE_BASELINES'
+	"""
+	Set this environment variable to a comma-separated list of performance (e.g. ``.csv``) files to print out an 
+	automatic comparison from the baseline file(s) to the results from the current test run. 
+	
+	This feature is very useful when comparing different strategies for optimizing your application. 
+	
+	For best results, use multiple cycles for all test runs so that standard deviation can be calculated. 
+	
+	The filenames can be absolute paths, glob paths using ``*`` and ``**``, or relative to the testRootDir. For example::
+	
+		export PYSYS_PERFORMANCE_BASELINES=__pysys_performance/mybaseline*/**/*.csv,__pysys_performance/optimization1*/**/*.csv
+		
+	"""
+
+	def setup(self, **kwargs):
+		super().setup()
+		self.results = []
+		
+		self.comparisonGenerator = pysys.perf.perfreportstool.PerformanceComparisonGenerator(reporters=self.runner.performanceReporters)
+		self.baselines = self.comparisonGenerator.loadFiles(
+			baselineBaseDir=self.project.testRootDir,
+			paths=os.getenv(self.BASELINES_ENV_VAR,'').split(','), 
+			)
+		log.info('Successfully loaded performance comparison data from %d files: %s', len(self.baselines), ', '.join(b.name for b in self.baselines))
+
+	def reportResult(self, testobj, value, resultKey, unit, toleranceStdDevs=None, resultDetails=None):
+		with self._lock:
+			self.results.append({
+						'resultKey':resultKey,
+						'value':value,
+						'unit':str(unit),
+						'biggerIsBetter':unit.biggerIsBetter,
+						'samples':1,
+						'stdDev':0,
+						'toleranceStdDevs':toleranceStdDevs,
+						'testId':testobj.descriptor.id,
+						'resultDetails':resultDetails or {}
+					})
+
+	def isEnabled(self, **kwargs):
+		return True
+	
+	def cleanup(self):
+		if not self.isEnabled(): return
+		if not self.results: return
+		
+		with self._lock:
+			logmethod = logging.getLogger('pysys.perfreporter.summary').info
+
+			# perform aggregation in case there are multiple cycles
+			p = PerformanceRunData.aggregate(PerformanceRunData('this', self.getRunDetails(), self.results))
+
+			if not self.baselines:
+				logmethod('Performance results summary:')
+				# simple formatting when there's no comparisons to be done
+				for r in p.results:
+					logmethod("  %s = %s %s (%s)%s %s", r['resultKey'], self.valueToDisplayString(r['value']), r['unit'],
+						 'bigger is better' if r['biggerIsBetter'] else 'smaller is better',
+							'' if r['samples']==1 or ['value'] == 0 else f", stdDev={self.valueToDisplayString(r['stdDev'])} ({100.0*r['stdDev']/r['value']:0.1f}% of mean)",
+							r['testId'],
+								extra = BaseLogFormatter.tag(LOG_TEST_PERFORMANCE, [0,1], suppress_prefix=True))
+				
+			else:
+				logmethod('\n')
+				self.comparisonGenerator.logComparisons(self.baselines+[p])
+
+class CSVPerformanceReporter(BasePerformanceReporter):
+	"""Performance reporter which writes to a CSV file.
+	
+	This reporter writes to a UTF-8 file of 
+	comma-separated values that is both machine and human readable and 
+	easy to view and use in any spreadsheet program, and after the columns containing 
+	the information for each result, contains comma-separated metadata containing 
+	key=value information about the entire run (e.g. hostname, date/time, etc), 
+	and (optionally) associated with each individual test result (e.g. test mode etc). 
+	The per-run and per-result metadata is not arranged in columns since the structure 
+	differs from row to row.
+
+	After tests have run, the summary file is published with category ``CSVPerformanceReport`` 
+	using the `pysys.writer.api.ArtifactPublisher` interface. 
+
+	The following properties can be set in the project configuration for this reporter:		
+	
+	"""
+	
+	summaryFile = ''
+	"""
+	The filename pattern used for the summary file(s); see `DEFAULT_SUMMARY_FILE`. 
+	
+	For compatibility purposes, if not specified explicitly, the summary file for the CSVPerformanceReporter can be 
+	configured with the project property ``csvPerformanceReporterSummaryFile``, however this is deprecated. 
+	This property can also be accessed and configured under the alternative capitalization ``summaryfile``, however this 
+	is discouraged as of PySys 2.1+, where ``summaryFile`` is the preferred name. 
+
+	"""
+
+	aggregateCycles = False
+	"""
+	Enable this if you want PySys to rewrite the summary file at the end of a multi-cycle test with an aggregated 
+	file containing the mean and standard deviation for all the cycles, rather than a separate line for each cycle. 
+	This may be easier to consume when triaging performance results and looking for regressions. 
+	
+	.. versionadded:: 2.1
+	"""
+
+	publishArtifactCategory = 'CSVPerformanceReport' 
+	"""
+	If specified, the output file will be published as an artifact using the specified category name. 
+
+	.. versionadded:: 2.1
+	"""
+
+	DEFAULT_SUMMARY_FILE = '__pysys_performance/${outDirName}_${hostname}/perf_${startDate}_${startTime}.${outDirName}.csv'
+	"""The default summary file if not overridden by the ``csvPerformanceReporterSummaryFile`` project property, or 
+	the ``summaryFile=`` attribute. See `getRunSummaryFile()`. This is relative to the runner output+'/..' directory 
+	(typically testRootDir, unless ``--outdir`` is overridden).
+	"""
+
+	def setup(self, **kwargs):
+		super().setup()
+
+		# for backwards compat
+		self.summaryfile = self.summaryfile or self.summaryFile or getattr(self.project, 'csvPerformanceReporterSummaryFile', '') or self.DEFAULT_SUMMARY_FILE
+
+		self.__summaryFilesWritten = set()
+
+	def getRunHeader(self, testobj=None, **kwargs):
+		"""Return the header string to the CSV file.
+		
+		There should usually be no reason to override this method. 
+		"""
+		
+		try:
+			runDetails = self.getRunDetails(testobj)
+		except Exception: # for pre-2.0 signature
+			runDetails = self.getRunDetails()
+		
+		return CSVPerformanceFile.makeCSVHeaderLine(runDetails)
+
+	def cleanup(self):
+		with self._lock:
+			if self.runner is not None and self.__summaryFilesWritten:
+				for p in sorted(list(self.__summaryFilesWritten)):
+					
+					if self.runner.cycle > 1 and self.aggregateCycles:
+						try:
+							perfFile = CSVPerformanceFile.load(p)
+							perfFile = CSVPerformanceFile.aggregate([perfFile])
+						except Exception as ex:
+							log.exception('Failed to read and aggregate performance information for %s: '%p)
+							# Don't make it fatal, more useful to go ahead and publish it as best we can
+						else:
+							log.info('Rewriting CSV to aggregate results across all %d cycles'%self.runner.cycles)
+							perfFile.dump(p)
+				
+					log.info('Performance results were written to: %s', os.path.normpath(p).replace(os.path.normpath(self.project.testRootDir), '').lstrip('/\\'))
+					log.info('  (add the above path to env %s to show a comparison against that baseline on future test runs)', PrintSummaryPerformanceReporter.BASELINES_ENV_VAR)
+					
+					if self.publishArtifactCategory:
+						self.runner.publishArtifact(p, self.publishArtifactCategory)
+
+	def reportResult(self, testobj, value, resultKey, unit, toleranceStdDevs=None, resultDetails=None):
+		formatted = self.formatResult(testobj, value, resultKey, unit, toleranceStdDevs, resultDetails)
+		self.recordResult(formatted, testobj)
+
+	def formatResult(self, testobj, value, resultKey, unit, toleranceStdDevs, resultDetails):
+		"""Retrieve an object representing the specified arguments that will be passed to recordResult to be written to the performance file(s).
+
+		:param testobj: the test case instance registering the value
+		:param value: the value to be reported
+		:param resultKey: a unique string that fully identifies what was measured
+		:param unit: identifies the unit the value is measured in
+		:param toleranceStdDevs: indicates how many standard deviations away from the mean for a regression
+		:param resultDetails:  A dictionary of detailed information that should be recorded together with the result
+
+		"""
+		data = {'resultKey':resultKey,
+				'testId':testobj.descriptor.id,
+				'value':str(value),
+				'unit':str(unit),
+				'biggerIsBetter':str(unit.biggerIsBetter).upper(),
+				'toleranceStdDevs':str(toleranceStdDevs) if toleranceStdDevs else '',
+				'samples':'1',
+				'stdDev':'0' ,
+				'resultDetails':resultDetails
+				}
+		return CSVPerformanceFile.toCSVLine(data)+'\n'
+
+	def recordResult(self, formatted, testobj):
+		"""Record results to the performance summary file.
+
+		:param formatted: the formatted string to write
+		:param testobj: object reference to the calling test
+
+		"""
+		# generate a file in the test output directory for convenience/triaging, plus add to the global summary
+		path = testobj.output+'/performance_results.csv'
+		encoding = 'utf-8'
+		
+		def callGetRunHeader():
+			try:
+				return self.getRunHeader(testobj)
+			except Exception: # for pre-2.0 signature
+				return self.getRunHeader()
+		
+		if not os.path.exists(path):
+			with io.open(toLongPathSafe(path), 'w', encoding=encoding) as f:
+				f.write(callGetRunHeader())
+		with io.open(toLongPathSafe(path), 'a', encoding=encoding) as f:
+			f.write(formatted)
+		
+		# now the global one
+		path = self.getRunSummaryFile(testobj)
+		mkdir(os.path.dirname(path))
+		with self._lock:
+			alreadyexists = os.path.exists(toLongPathSafe(path))
+			with io.open(toLongPathSafe(path), 'a', encoding=encoding) as f:
+				if not alreadyexists: 
+					testobj.log.info('Creating performance summary log file at: %s', os.path.normpath(path))
+					f.write(callGetRunHeader())
+				f.write(formatted)
+			self.__summaryFilesWritten.add(path)
+	
+	@staticmethod
+	def tryDeserializePerformanceFile(path):
+		if not path.endswith('.csv'): return None
+		return CSVPerformanceFile.load(path)
+

--- a/pysys/process/user.py
+++ b/pysys/process/user.py
@@ -1796,7 +1796,7 @@ class ProcessUser(object):
 
 
 	def logFileContents(self, path, includes=None, excludes=None, maxLines=20, tail=False, encoding=None, 
-			logFunction=None, reFlags=0, stripWhitespace=True, mappers=[]):
+			logFunction=None, reFlags=0, stripWhitespace=True, mappers=[], color=True):
 		""" Logs some or all of the lines from the specified file.
 		
 		If the file does not exist or cannot be opened, does nothing. The method is useful for providing key
@@ -1845,6 +1845,9 @@ class ProcessUser(object):
 
 		:param bool stripWhitespace: By default blank lines are removed; set this to False to disable that behaviour. 
 			Added in PySys 2.0. 
+		
+		:param bool color: By default logged lines are colored blue to distinguish from the rest of the log contents. 
+			Set this to False to disable coloring. Added in PySys 2.1. 
 
 		:return: True if anything was logged, False if not.
 		
@@ -1895,12 +1898,12 @@ class ProcessUser(object):
 		if not tolog:
 			return False
 		
-		logextra = BaseLogFormatter.tag(LOG_FILE_CONTENTS, suppress_prefix=True)
+		logextra = BaseLogFormatter.tag(LOG_FILE_CONTENTS if color else None, suppress_prefix=True)
 		if logFunction is None: 
 			def logFunction(line):
 				self.log.info(u'  %s', l, 
 					# special-case printing of lines that already have coloring - don't add any extra colors to such lines
-					extra=BaseLogFormatter.tag(None, suppress_prefix=True) if '\033[' in line else logextra)
+					extra=BaseLogFormatter.tag(None, suppress_prefix=True) if color and '\033[' in line else logextra)
 
 		path = os.path.normpath(path)
 		if path.startswith(self.output): path = path[len(self.output)+1:]

--- a/pysys/process/user.py
+++ b/pysys/process/user.py
@@ -1898,7 +1898,9 @@ class ProcessUser(object):
 		logextra = BaseLogFormatter.tag(LOG_FILE_CONTENTS, suppress_prefix=True)
 		if logFunction is None: 
 			def logFunction(line):
-				self.log.info(u'  %s', l, extra=logextra)
+				self.log.info(u'  %s', l, 
+					# special-case printing of lines that already have coloring - don't add any extra colors to such lines
+					extra=BaseLogFormatter.tag(None, suppress_prefix=True) if '\033[' in line else logextra)
 
 		path = os.path.normpath(path)
 		if path.startswith(self.output): path = path[len(self.output)+1:]

--- a/pysys/process/user.py
+++ b/pysys/process/user.py
@@ -1874,6 +1874,8 @@ class ProcessUser(object):
 				if stripWhitespace:
 					l = l.rstrip()
 					if len(l) == 0: continue
+				else:
+					l = l.strip('\n\r')
 				
 				if includes:
 					l = matchesany(l, includes)
@@ -1893,14 +1895,15 @@ class ProcessUser(object):
 		if not tolog:
 			return False
 		
-		logextra = BaseLogFormatter.tag(LOG_FILE_CONTENTS)
+		logextra = BaseLogFormatter.tag(LOG_FILE_CONTENTS, suppress_prefix=True)
 		if logFunction is None: 
 			def logFunction(line):
 				self.log.info(u'  %s', l, extra=logextra)
 
 		path = os.path.normpath(path)
 		if path.startswith(self.output): path = path[len(self.output)+1:]
-		self.log.info(u'Contents of %s%s: ', fromLongPathSafe(path), ' (filtered)' if includes or excludes else '', extra=logextra)
+		self.log.info(u'Contents of %s%s: ', fromLongPathSafe(path), ' (filtered)' if includes or excludes else '', 
+			extra=BaseLogFormatter.tag(LOG_FILE_CONTENTS, suppress_prefix=False))
 		for l in tolog:
 			logFunction(l)
 		self.log.info('  -----', extra=logextra)

--- a/pysys/utils/logutils.py
+++ b/pysys/utils/logutils.py
@@ -276,7 +276,7 @@ class ColorLogFormatter(BaseLogFormatter):
 						for index in indexes: args[index] = self.formatArg(cat, args[index])
 						record.args = tuple(args)
 					
-			except Exception as e:
+			except Exception as e: # pragma: no cover
 				logging.getLogger('pysys.utils.logutils').debug('Failed to format log message "%s": %s'%(record.msg, repr(e)))
 
 		if getattr(record, self.SUPPRESS_PREFIX, False):

--- a/pysys/utils/logutils.py
+++ b/pysys/utils/logutils.py
@@ -131,6 +131,8 @@ class ColorLogFormatter(BaseLogFormatter):
 		LOG_PASSES: 'GREEN',
 		LOG_SKIPS: 'YELLOW',
 		LOG_DIFF_ADDED: 'CYAN', LOG_DIFF_REMOVED: 'MAGENTA', # can't use red/green here without confusion with fail/pass
+		LOG_PERF_BETTER:'GREEN', LOG_PERF_WORSE:'RED',
+		
 		LOG_END:'END',
 	}
 	

--- a/pysys/utils/perfreporter.py
+++ b/pysys/utils/perfreporter.py
@@ -81,6 +81,14 @@ class PerformanceRunData:
 		self.runDetails = runDetails
 		self.results = results
 
+	def __maybequote(self, s):
+		return '"%s"' % s if isstring(s) else s
+	def __str__(self):
+		return 'PerformanceRunData< %d results; runDetails: %s>'%(len(self.results), ', '.join([('%s=%s'%(k, self.__maybequote(self.runDetails[k]))) for k in self.runDetails]))
+	def __repr__(self):
+		return 'PerformanceRunData<runDetails: %s%s\n>'%(', '.join([('%s="%s"'%(k, self.runDetails[k])) for k in self.runDetails]),
+			''.join([('\n - %s'%(', '.join([('%s=%s'%(k, self.__maybequote(r.get(k, r.get('resultDetails',{}).get(k,None))))) for k in list(r.keys())+list(r.get('resultDetails',{}).keys()) if k!='resultDetails']))) for r in self.results]))
+
 	@staticmethod
 	def aggregate(runs):
 		"""Aggregate a list of multiple runs and/or cycles into a single performance run data object with a single 
@@ -626,18 +634,6 @@ class CSVPerformanceFile(PerformanceRunData):
 				raise Exception('Cannot parse performance line - %s (%s): "%s"'%(e, e.__class__.__name__, l))
 		
 		if self.runDetails == None: self.runDetails = collections.OrderedDict()
-
-	def __maybequote(self, s):
-		return '"%s"' % s if isstring(s) else s
-		
-	def __str__(self):
-		return 'CSVPerformanceFile< %d results; runDetails: %s>'%(len(self.results), ', '.join([('%s=%s'%(k, self.__maybequote(self.runDetails[k]))) for k in self.runDetails]))
-
-	def __repr__(self):
-		return 'CSVPerformanceFile<runDetails: %s%s\n>'%(', '.join([('%s="%s"'%(k, self.runDetails[k])) for k in self.runDetails]),
-			''.join([('\n - %s'%(', '.join([('%s=%s'%(k, self.__maybequote(r.get(k, r.get('resultDetails',{}).get(k,None))))) for k in list(r.keys())+list(r.get('resultDetails',{}).keys()) if k!='resultDetails']))) for r in self.results]))
-
-
 
 if __name__ == "__main__":
 	USAGE = """

--- a/pysys/utils/perfreporter.py
+++ b/pysys/utils/perfreporter.py
@@ -132,6 +132,13 @@ class CSVPerformanceReporter(object):
 	.. versionadded:: 2.1
 	"""
 
+	publishArtifactCategory = 'CSVPerformanceReport' 
+	"""
+	If specified, the output file will be published as an artifact using the specified category name. 
+
+	.. versionadded:: 2.1
+	"""
+
 	DEFAULT_SUMMARY_FILE = '__pysys_performance/${outDirName}_${hostname}/perf_${startDate}_${startTime}.${outDirName}.csv'
 	"""The default summary file if not overridden by the ``csvPerformanceReporterSummaryFile`` project property, or 
 	the ``summaryfile=`` attribute. See `getRunSummaryFile()`. This is relative to the runner output+'/..' directory 
@@ -263,7 +270,8 @@ class CSVPerformanceReporter(object):
 							log.info('Rewriting CSV to aggregate results across all %d cycles'%self.runner.cycles)
 							perfFile.dump(p)
 				
-					self.runner.publishArtifact(p, 'CSVPerformanceReport')
+					if self.publishArtifactCategory:
+						self.runner.publishArtifact(p, self.publishArtifactCategory)
 
 	def reportResult(self, testobj, value, resultKey, unit, toleranceStdDevs=None, resultDetails=None):
 		"""Report a performance result, with an associated unique key that identifies it.

--- a/pysys/utils/perfreporter.py
+++ b/pysys/utils/perfreporter.py
@@ -337,6 +337,7 @@ class PrintSummaryPerformanceReporter(BasePerformanceReporter):
 			baselineBaseDir=self.project.testRootDir,
 			paths=os.getenv(self.BASELINES_ENV_VAR,'').split(','), 
 			)
+		log.info('Successfully loaded performance comparison data from %d files: %s', len(self.baselines), ', '.join(b.name for b in self.baselines))
 
 	def reportResult(self, testobj, value, resultKey, unit, toleranceStdDevs=None, resultDetails=None):
 		with self._lock:

--- a/pysys/utils/perfreporter.py
+++ b/pysys/utils/perfreporter.py
@@ -324,9 +324,7 @@ class PrintSummaryPerformanceReporter(BasePerformanceReporter):
 					 'bigger is better' if r['biggerIsBetter'] else 'smaller is better',
 						'' if r['samples']==1 else ', stdDev = '+self.valueToDisplayString(r['stdDev']),
 						r['testId'],
-							extra = BaseLogFormatter.tag(LOG_TEST_PERFORMANCE, [0,1]))
-
-			logger.info('')
+							extra = BaseLogFormatter.tag(LOG_TEST_PERFORMANCE, [0,1], suppress_prefix=True))
 
 class CSVPerformanceReporter(BasePerformanceReporter):
 	"""Performance reporter which writes to a CSV file.

--- a/pysys/utils/perfreporter.py
+++ b/pysys/utils/perfreporter.py
@@ -37,7 +37,8 @@ from pysys.utils.pycompat import *
 from pysys.perf.perfreportstool import perfReportsToolMain
 
 # For backwards compatibility where modules are importing this
-from pysys.perf.reporters import *#CSVPerformanceReporter
+from pysys.perf.reporters import *
+from pysys.perf.api import PerformanceUnit
 
 if __name__ == "__main__":
 	perfReportsToolMain(sys.argv[1:])

--- a/pysys/utils/perfreporter.py
+++ b/pysys/utils/perfreporter.py
@@ -581,8 +581,8 @@ class CSVPerformanceFile(PerformanceRunData):
 			raise Exception('Unsupported input type: %s'%values.__class__.__name__)
 		
 	def __init__(self, contents):
+		super().__init__(None, [])
 		header = None
-		self.results = []
 		self.runDetails = None
 		for l in contents.split('\n'):
 			l = l.strip()

--- a/pysys/utils/safeeval.py
+++ b/pysys/utils/safeeval.py
@@ -22,6 +22,10 @@
 
 # It still contains lots of symbols which are likely to be useful when performing an eval such as IS_WINDOWS, etc
 
+"""
+Contains the `safeEval` function.
+"""
+
 import os.path, time, threading, logging, sys
 import re
 import math

--- a/pysys/writer/api.py
+++ b/pysys/writer/api.py
@@ -275,7 +275,7 @@ class ArtifactPublisher(object):
 			"CSVPerformanceReport" (from `pysys.perf.reporters.CSVPerformanceReporter`). 
 			If you create your own category, be sure to add an org/company name prefix to avoid clashes.
 		"""
-		pass
+		pass # pragma: no cover
 
 
 class TestOutputVisitor(object):

--- a/pysys/writer/api.py
+++ b/pysys/writer/api.py
@@ -415,7 +415,7 @@ class TestOutcomeSummaryGenerator(BaseResultsWriter):
 		if showRunDetails:
 			log("Run details:")
 			for k, v in self.runner.runDetails.items():
-				log(" %23s%s", k+': ', v, extra=ColorLogFormatter.tag(LOG_TEST_DETAILS, 1))
+				log(" %23s%s", k+': ', '%s'%v, extra=ColorLogFormatter.tag(LOG_TEST_DETAILS, 1))
 			log("")
 
 		if showOutcomeStats:

--- a/pysys/writer/api.py
+++ b/pysys/writer/api.py
@@ -51,6 +51,9 @@ The most common type of writer is the standard 'Record' writer, but there are al
      that did not pass. 
      Summary writers are always enabled regardless of the flags given to the PySys launcher.
 
+(See also `pysys.utils.perfreporter` whcih is used for writing performance results, using a similar but slightly 
+different API).
+
 Project configuration of the writers is through the PySys project XML file using the ``<writer>`` tag. Multiple
 writers may be configured and their individual properties set through the nested ``<property>`` tag. Writer
 properties are set as attributes to the writer instance just before setup is called, with automatic conversion of 

--- a/pysys/writer/api.py
+++ b/pysys/writer/api.py
@@ -51,7 +51,7 @@ The most common type of writer is the standard 'Record' writer, but there are al
      that did not pass. 
      Summary writers are always enabled regardless of the flags given to the PySys launcher.
 
-(See also `pysys.utils.perfreporter` whcih is used for writing performance results, using a similar but slightly 
+(See also `pysys.perf.api` whcih is used for writing performance results, using a similar but slightly 
 different API).
 
 Project configuration of the writers is through the PySys project XML file using the ``<writer>`` tag. Multiple
@@ -272,7 +272,7 @@ class ArtifactPublisher(object):
 		:param str path: Absolute path of the file or directory, using forward slashes as the path separator. 
 		:param str category: A string identifying what kind of artifact this is, e.g. 
 			"TestOutputArchive" and "TestOutputArchiveDir" (from `pysys.writer.testoutput.TestOutputArchiveWriter`) or 
-			"CSVPerformanceReport" (from `pysys.utils.perfreporter.CSVPerformanceReporter`). 
+			"CSVPerformanceReport" (from `pysys.perf.reporters.CSVPerformanceReporter`). 
 			If you create your own category, be sure to add an org/company name prefix to avoid clashes.
 		"""
 		pass

--- a/samples/cookbook/test/pysysproject.xml
+++ b/samples/cookbook/test/pysysproject.xml
@@ -300,7 +300,7 @@
 	</writers>
 
 	<!--
-	Performance Reporters
+	Performance reporters
 	~~~~~~~~~~~~~~~~~~~~~
 	
 	By default PySys will record performance results using a default instance of 

--- a/samples/cookbook/test/pysysproject.xml
+++ b/samples/cookbook/test/pysysproject.xml
@@ -304,19 +304,19 @@
 	~~~~~~~~~~~~~~~~~~~~~
 	
 	By default PySys will record performance results using a default instance of 
-	`pysys.utils.perfreporter.CSVPerformanceReporter`. However if desired you can configure an alternative list of 
-	reporters such as `pysys.utils.perfreporter.JSONPerformanceReporter` or custom reporters of your own. 
+	`pysys.perf.reporters.CSVPerformanceReporter`. However if desired you can configure an alternative list of 
+	reporters such as `pysys.perf.reporters.JSONPerformanceReporter` or custom reporters of your own. 
 	-->
 	<performance-reporters>
 	
-		<performance-reporter classname="pysys.utils.perfreporter.CSVPerformanceReporter">
+		<performance-reporter classname="pysys.perf.reporters.CSVPerformanceReporter">
 			<property name="aggregateCycles" value="true"/>
 			<property name="summaryFile" value="__pysys_performance/${outDirName}_${hostname}/perf_${startDate}_${startTime}.${outDirName}.csv"/>
 		</performance-reporter>
 		
-		<performance-reporter classname="pysys.utils.perfreporter.JSONPerformanceReporter"/>
+		<performance-reporter classname="pysys.perf.reporters.JSONPerformanceReporter"/>
 
-		<performance-reporter classname="pysys.utils.perfreporter.PrintSummaryPerformanceReporter"/>
+		<performance-reporter classname="pysys.perf.reporters.PrintSummaryPerformanceReporter"/>
 		
 	</performance-reporters>
 	

--- a/samples/cookbook/test/pysysproject.xml
+++ b/samples/cookbook/test/pysysproject.xml
@@ -315,6 +315,8 @@
 		</performance-reporter>
 		
 		<performance-reporter classname="pysys.utils.perfreporter.JSONPerformanceReporter"/>
+
+		<performance-reporter classname="pysys.utils.perfreporter.PrintSummaryPerformanceReporter"/>
 		
 	</performance-reporters>
 	

--- a/samples/cookbook/test/pysysproject.xml
+++ b/samples/cookbook/test/pysysproject.xml
@@ -299,6 +299,25 @@
 		</writer>
 	</writers>
 
+	<!--
+	Performance Reporters
+	~~~~~~~~~~~~~~~~~~~~~
+	
+	By default PySys will record performance results using a default instance of 
+	`pysys.utils.perfreporter.CSVPerformanceReporter`. However if desired you can configure an alternative list of 
+	reporters such as `pysys.utils.perfreporter.JSONPerformanceReporter` or custom reporters of your own. 
+	-->
+	<performance-reporters>
+	
+		<performance-reporter classname="pysys.utils.perfreporter.CSVPerformanceReporter">
+			<property name="aggregateCycles" value="true"/>
+			<property name="summaryFile" value="__pysys_performance/${outDirName}_${hostname}/perf_${startDate}_${startTime}.${outDirName}.csv"/>
+		</performance-reporter>
+		
+		<performance-reporter classname="pysys.utils.perfreporter.JSONPerformanceReporter"/>
+		
+	</performance-reporters>
+	
 	<!-- 
 	Configuration for how tests execute
 	~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/test/correctness/PySys_internal_065/Input/extrapath/mypkg/customperf.py
+++ b/test/correctness/PySys_internal_065/Input/extrapath/mypkg/customperf.py
@@ -2,12 +2,16 @@ from pysys.utils.perfreporter import CSVPerformanceReporter
 import logging
 
 class CustomPerfReporter(CSVPerformanceReporter):
+	myDefaultedProperty = 5
+
 	def __init__(self, project, summaryfile, testoutdir, runner, **kwargs):
 		super(CustomPerfReporter, self).__init__(project, summaryfile, testoutdir, runner, **kwargs)
 		assert self.runner is not None
 	
 	def getRunHeader(self, testobj, **kwargs): # new signature with testobj
 		assert testobj
+		assert self.myproperty == 'my_project_value'
+		assert self.myDefaultedProperty == 10
 		return '<custom reporter>\n'+super(CustomPerfReporter, self).getRunHeader()
 
 	def getRunDetails(self): # deprecated legacy signature without testobj

--- a/test/correctness/PySys_internal_065/Input/pysysproject.xml
+++ b/test/correctness/PySys_internal_065/Input/pysysproject.xml
@@ -12,6 +12,8 @@
 	<pythonpath value="${root}/extrapath"/>
 	<property name="csvPerformanceReporterSummaryFile" value="${perfparent}/@OUTDIR@_@TESTID@_perf_@HOSTNAME@_@DATE@_${startTime}.csv"/>
 
-	<performance-reporter classname="CustomPerfReporter" module="mypkg.customperf" />
+	<property name="myProjectProp" value="my_project_value"/>
+
+	<performance-reporter classname="CustomPerfReporter" module="mypkg.customperf" myproperty="${myProjectProp}" myDefaultedProperty="10"/>
 	
 </pysysproject>

--- a/test/correctness/PySys_internal_065/Reference/parsed_perf_contrived_data.txt
+++ b/test/correctness/PySys_internal_065/Reference/parsed_perf_contrived_data.txt
@@ -1,4 +1,4 @@
-CSVPerformanceFile<runDetails: 
+PerformanceRunData<runDetails: 
  - testId="testid1", value=0.0, resultKey="my result key1", foobar="foobarval", unit="unitval", biggerIsBetter=False, toleranceStdDevs=0.0, samples=-1, stdDev=-1.0
  - testId="testid1", value=0.0, resultKey="my result key1", foobar="foobarval", unit="unitval", biggerIsBetter=False, toleranceStdDevs=0.0, samples=-1, stdDev=-1.0
  - testId="testid2", value=0.0, resultKey="my result key2", foobar="foobarval2", unit="unitval", biggerIsBetter=False, toleranceStdDevs=0.0, samples=-1, stdDev=-1.0

--- a/test/correctness/PySys_internal_065/Reference/parsed_perf_genuine_data.txt
+++ b/test/correctness/PySys_internal_065/Reference/parsed_perf_genuine_data.txt
@@ -1,4 +1,4 @@
-CSVPerformanceFile<runDetails: outDirName="myoutdir", hostname="mcbsp02", startTime="2018-08-30 14:49:53", myBuildNumber="1.23.45X"
+PerformanceRunData<runDetails: outDirName="myoutdir", hostname="mcbsp02", startTime="2018-08-30 14:49:53", myBuildNumber="1.23.45X"
  - resultKey="Sample small integer performance result", testId="PySys_NestedTestcase", value=123.0, unit="s", biggerIsBetter=False, toleranceStdDevs=0.0, samples=1, stdDev=0.0, someResultDetail="value;yesitis"
  - resultKey="Sample large integer performance result", testId="PySys_NestedTestcase", value=1234.0, unit="s", biggerIsBetter=False, toleranceStdDevs=0.0, samples=1, stdDev=0.0, someResultDetail="value;yesitis"
  - resultKey="Sample float performance result", testId="PySys_NestedTestcase", value=0.012341, unit="/s", biggerIsBetter=True, toleranceStdDevs=0.0, samples=1, stdDev=0.0

--- a/test/correctness/PySys_internal_065/pysystest.xml
+++ b/test/correctness/PySys_internal_065/pysystest.xml
@@ -2,7 +2,7 @@
 <pysystest type="auto" state="runnable">
     
   <description> 
-    <title>PerformanceReporter configuration</title>    
+    <title>PerformanceReporter - custom subclass of CSV, command line aggregation</title>    
     <purpose><![CDATA[
 Checks that it is possible to provide a custom performance reporter subclass. 
 ]]>

--- a/test/correctness/PySys_internal_065/run.py
+++ b/test/correctness/PySys_internal_065/run.py
@@ -32,6 +32,8 @@ class PySysTest(BaseTest):
 		self.startPython([perfreporterexe, 'aggregate', self.input+'/sample.csv'], stdouterr='perfreporter-aggregate', abortOnError=False)
 		
 	def validate(self):
+		self.assertGrep('pysys.out', 'Sample small integer performance result.*123') # ensure we print the result to the console
+	
 		defaultPerfFilename=glob.glob(self.output+'/test/__pysys_performance/*/*.csv')[0]
 		defaultPerfFilename = '/'.join(defaultPerfFilename.replace('\\','/').split('/')[-3:])
 		self.assertThat('"$" not in defaultPerfFilename', defaultPerfFilename=defaultPerfFilename)

--- a/test/correctness/PySys_internal_150/run.py
+++ b/test/correctness/PySys_internal_150/run.py
@@ -1,3 +1,5 @@
+import glob
+import json
 import pysys
 from pysys.constants import *
 from pysys.basetest import BaseTest
@@ -63,3 +65,9 @@ class PySysTest(BaseTest):
 		# Custom runner
 		self.assertGrep('pysys-run-tests.out', 'MyRunner.setup was called; myRunnerArg=12345')
 		self.assertGrep('pysys-run-tests.out', 'MyRunner.cleanup was called')
+
+		if self.assertThat('len(performanceFiles)==2 and ".json" in "".join(performanceFiles)', performanceFiles=glob.glob(outdir+'/__pysys_performance/*/*')):
+			# check it's valid json
+			with open(glob.glob(outdir+'/__pysys_performance/*/*.json')[0]) as f:
+				json.load(f)
+		

--- a/test/correctness/PySys_internal_178/Input/MyNestedTestcase/pysystest.py
+++ b/test/correctness/PySys_internal_178/Input/MyNestedTestcase/pysystest.py
@@ -1,7 +1,7 @@
 __pysys_title__   = r""" Nested """ 
 #                        ================================================================================
 
-__pysys_modes__ = "lambda helper: {'MyMode': {}}"
+__pysys_modes__ = "lambda helper: {'MyMode': {'ModeParamA':123, 'ModeParamB':'Foo'}}"
 
 import pysys
 from pysys.constants import *

--- a/test/correctness/PySys_internal_178/Input/MyNestedTestcase/pysystest.py
+++ b/test/correctness/PySys_internal_178/Input/MyNestedTestcase/pysystest.py
@@ -1,0 +1,16 @@
+__pysys_title__   = r""" Nested """ 
+#                        ================================================================================
+
+import pysys
+from pysys.constants import *
+
+import os, sys, math, shutil, glob
+
+class PySysTest(pysys.basetest.BaseTest):
+
+	def execute(self):
+		self.reportPerformanceResult(1000+(self.testCycle+1)*10, 'Rate of doing a foo bar', '/s')
+		self.reportPerformanceResult(2000+(self.testCycle+1), 'Rate of doing a bar baz', '/s')
+		
+	def validate(self):
+		self.addOutcome(PASSED)

--- a/test/correctness/PySys_internal_178/Input/MyNestedTestcase/pysystest.py
+++ b/test/correctness/PySys_internal_178/Input/MyNestedTestcase/pysystest.py
@@ -10,7 +10,7 @@ class PySysTest(pysys.basetest.BaseTest):
 
 	def execute(self):
 		self.reportPerformanceResult(1000+(self.testCycle+1)*10, 'Rate of doing a foo bar', '/s')
-		self.reportPerformanceResult(2000+(self.testCycle+1), 'Rate of doing a bar baz', '/s')
+		self.reportPerformanceResult(2000+(self.testCycle+1), 'Rate of doing a badda-badda-bing', '/s')
 		
 	def validate(self):
 		self.addOutcome(PASSED)

--- a/test/correctness/PySys_internal_178/Input/pysysproject.xml
+++ b/test/correctness/PySys_internal_178/Input/pysysproject.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" standalone="yes"?>
+<pysysproject>
+	<!--
+	<pysysdirconfig>
+	</pysysdirconfig>
+	-->
+
+
+	<default-file-encodings>
+		<default-file-encoding pattern="run.log" encoding="utf-8"/>
+		
+		<default-file-encoding pattern="*.xml" encoding="utf-8"/>
+		<default-file-encoding pattern="*.json" encoding="utf-8"/>
+		<default-file-encoding pattern="*.yaml" encoding="utf-8"/>
+		
+	</default-file-encodings>	
+	
+</pysysproject>

--- a/test/correctness/PySys_internal_178/Reference/perf-summary.out
+++ b/test/correctness/PySys_internal_178/Reference/perf-summary.out
@@ -1,2 +1,2 @@
-INFO    Rate of doing a badda-badda-bing = 2,003 /s (bigger is better), stdDev = 1
-INFO    Rate of doing a foo bar = 1,030 /s (bigger is better), stdDev = 10
+INFO    Rate of doing a badda-badda-bing = 2,003 /s (bigger is better), stdDev = 1 (MyNestedTestcase~MyMode)
+INFO    Rate of doing a foo bar = 1,030 /s (bigger is better), stdDev = 10 (MyNestedTestcase~MyMode)

--- a/test/correctness/PySys_internal_178/Reference/perf-summary.out
+++ b/test/correctness/PySys_internal_178/Reference/perf-summary.out
@@ -1,2 +1,2 @@
-INFO    Rate of doing a badda-badda-bing = 2,003 /s (bigger is better), stdDev = 1 (MyNestedTestcase~MyMode)
-INFO    Rate of doing a foo bar = 1,030 /s (bigger is better), stdDev = 10 (MyNestedTestcase~MyMode)
+  Rate of doing a badda-badda-bing = 2,003 /s (bigger is better), stdDev = 1 (MyNestedTestcase~MyMode)
+  Rate of doing a foo bar = 1,030 /s (bigger is better), stdDev = 10 (MyNestedTestcase~MyMode)

--- a/test/correctness/PySys_internal_178/Reference/perf-summary.out
+++ b/test/correctness/PySys_internal_178/Reference/perf-summary.out
@@ -1,2 +1,2 @@
-  Rate of doing a badda-badda-bing = 2,003 /s (bigger is better), stdDev = 1 (MyNestedTestcase~MyMode)
-  Rate of doing a foo bar = 1,030 /s (bigger is better), stdDev = 10 (MyNestedTestcase~MyMode)
+  Rate of doing a badda-badda-bing = 2,003 /s (bigger is better), stdDev=1 (0.0% of mean) MyNestedTestcase~MyMode
+  Rate of doing a foo bar = 1,030 /s (bigger is better), stdDev=10 (1.0% of mean) MyNestedTestcase~MyMode

--- a/test/correctness/PySys_internal_178/Reference/perf-summary.out
+++ b/test/correctness/PySys_internal_178/Reference/perf-summary.out
@@ -1,0 +1,2 @@
+INFO    Rate of doing a badda-badda-bing = 2,003 /s (bigger is better), stdDev = 1
+INFO    Rate of doing a foo bar = 1,030 /s (bigger is better), stdDev = 10

--- a/test/correctness/PySys_internal_178/pysystest.py
+++ b/test/correctness/PySys_internal_178/pysystest.py
@@ -1,4 +1,4 @@
-__pysys_title__   = r""" PerformanceReporter - default configuration, with end-of-cycle aggregation """ 
+__pysys_title__   = r""" PerformanceReporter - default configuration, multi-cycle aggregation, summary""" 
 #                        ================================================================================
 
 __pysys_purpose__ = r""" 
@@ -24,7 +24,7 @@ class PySysTest(pysys.basetest.BaseTest):
 
 	def execute(self):
 		self.pysys.pysys('pysys-run', ['run', '-o', self.output+'/myoutdir', '--cycle=3'], workingDir=self.input)
-		self.logFileContents('pysys-run.out')
+		self.logFileContents('pysys-run.out', tail=True)
 		
 	def validate(self):
 		path = self.grep('pysys-run.out', 'Creating performance summary log file at: (.+)')
@@ -33,3 +33,8 @@ class PySysTest(pysys.basetest.BaseTest):
 		self.assertThat('resultsLen == expected', resultsLen=len(f.results), expected=2)
 		self.assertThat('result1samples == expected', result1samples=f.results[0]['samples'], expected=3)
 		self.assertThat('result2stdDev == expected', result2stdDev=f.results[-1]['stdDev'], expected=10.0)
+
+		self.assertDiff(self.copy('pysys-run.out', 'perf-summary.out', mappers=[
+			pysys.mappers.RegexReplace(pysys.mappers.RegexReplace.DATETIME_REGEX+' ', ''),
+			pysys.mappers.IncludeLinesBetween(startAfter='Summary of performance results ', stopBefore='^INFO *$'),
+		]))

--- a/test/correctness/PySys_internal_178/pysystest.py
+++ b/test/correctness/PySys_internal_178/pysystest.py
@@ -28,6 +28,5 @@ class PySysTest(pysys.basetest.BaseTest):
 		path = self.grep('pysys-run.out', 'Creating performance summary log file at: (.+)')
 
 		self.assertDiff(self.copy('pysys-run.out', 'perf-summary.out', mappers=[
-			pysys.mappers.RegexReplace(pysys.mappers.RegexReplace.DATETIME_REGEX+' ', ''),
-			pysys.mappers.IncludeLinesBetween(startAfter='Summary of performance results:', stopBefore='^(INFO|CRIT) *$'),
+			pysys.mappers.IncludeLinesBetween(startAfter='Summary of performance results:', stopBefore=' (INFO|CRIT) *$'),
 		]))

--- a/test/correctness/PySys_internal_178/pysystest.py
+++ b/test/correctness/PySys_internal_178/pysystest.py
@@ -1,0 +1,35 @@
+__pysys_title__   = r""" PerformanceReporter - default configuration, with end-of-cycle aggregation """ 
+#                        ================================================================================
+
+__pysys_purpose__ = r""" 
+	
+	""" 
+	
+__pysys_authors__ = "bsp"
+__pysys_created__ = "2022-02-04"
+
+#__pysys_traceability_ids__ = "Bug-1234, UserStory-456" 
+#__pysys_groups__           = "myGroup, disableCoverage, performance; inherit=true"
+#__pysys_skipped_reason__   = "Skipped until Bug-1234 is fixed"
+#__pysys_modes__            = """ lambda helper: helper.combineModeDimensions(helper.inheritedModes, helper.makeAllPrimary({'MyMode':{'MyParam':123}})) """
+
+import pysys
+from pysys.constants import *
+
+from pysys.utils.perfreporter import CSVPerformanceFile
+
+import os, sys, math, shutil, glob
+
+class PySysTest(pysys.basetest.BaseTest):
+
+	def execute(self):
+		self.pysys.pysys('pysys-run', ['run', '-o', self.output+'/myoutdir', '--cycle=3'], workingDir=self.input)
+		self.logFileContents('pysys-run.out')
+		
+	def validate(self):
+		path = self.grep('pysys-run.out', 'Creating performance summary log file at: (.+)')
+		f = CSVPerformanceFile.load(path)
+		self.assertThat('len(runDetails) > 0', runDetails=f.runDetails) # not empty
+		self.assertThat('resultsLen == expected', resultsLen=len(f.results), expected=2)
+		self.assertThat('result1samples == expected', result1samples=f.results[0]['samples'], expected=3)
+		self.assertThat('result2stdDev == expected', result2stdDev=f.results[-1]['stdDev'], expected=10.0)

--- a/test/correctness/PySys_internal_178/pysystest.py
+++ b/test/correctness/PySys_internal_178/pysystest.py
@@ -1,4 +1,4 @@
-__pysys_title__   = r""" PerformanceReporter - default configuration, multi-cycle aggregation, summary""" 
+__pysys_title__   = r""" PerformanceReporter - default configuration, summary""" 
 #                        ================================================================================
 
 __pysys_purpose__ = r""" 
@@ -16,8 +16,6 @@ __pysys_created__ = "2022-02-04"
 import pysys
 from pysys.constants import *
 
-from pysys.utils.perfreporter import CSVPerformanceFile
-
 import os, sys, math, shutil, glob
 
 class PySysTest(pysys.basetest.BaseTest):
@@ -28,13 +26,8 @@ class PySysTest(pysys.basetest.BaseTest):
 		
 	def validate(self):
 		path = self.grep('pysys-run.out', 'Creating performance summary log file at: (.+)')
-		f = CSVPerformanceFile.load(path)
-		self.assertThat('len(runDetails) > 0', runDetails=f.runDetails) # not empty
-		self.assertThat('resultsLen == expected', resultsLen=len(f.results), expected=2)
-		self.assertThat('result1samples == expected', result1samples=f.results[0]['samples'], expected=3)
-		self.assertThat('result2stdDev == expected', result2stdDev=f.results[-1]['stdDev'], expected=10.0)
 
 		self.assertDiff(self.copy('pysys-run.out', 'perf-summary.out', mappers=[
 			pysys.mappers.RegexReplace(pysys.mappers.RegexReplace.DATETIME_REGEX+' ', ''),
-			pysys.mappers.IncludeLinesBetween(startAfter='Summary of performance results ', stopBefore='^INFO *$'),
+			pysys.mappers.IncludeLinesBetween(startAfter='Summary of performance results:', stopBefore='^(INFO|CRIT) *$'),
 		]))

--- a/test/correctness/PySys_internal_178/pysystest.py
+++ b/test/correctness/PySys_internal_178/pysystest.py
@@ -28,5 +28,5 @@ class PySysTest(pysys.basetest.BaseTest):
 		path = self.grep('pysys-run.out', 'Creating performance summary log file at: (.+)')
 
 		self.assertDiff(self.copy('pysys-run.out', 'perf-summary.out', mappers=[
-			pysys.mappers.IncludeLinesBetween(startAfter='Summary of performance results:', stopBefore=' (INFO|CRIT) *$'),
+			pysys.mappers.IncludeLinesBetween(startAfter='Performance results summary:', stopBefore=' (INFO|CRIT) *$'),
 		]))

--- a/test/correctness/PySys_internal_178/pysystest.py
+++ b/test/correctness/PySys_internal_178/pysystest.py
@@ -1,4 +1,4 @@
-__pysys_title__   = r""" PerformanceReporter - default configuration, summary""" 
+__pysys_title__   = r""" PerformanceReporter - default configuration, summary, disablePerformanceReporting""" 
 #                        ================================================================================
 
 __pysys_purpose__ = r""" 
@@ -23,6 +23,8 @@ class PySysTest(pysys.basetest.BaseTest):
 	def execute(self):
 		self.pysys.pysys('pysys-run', ['run', '-o', self.output+'/myoutdir', '--cycle=3'], workingDir=self.input)
 		self.logFileContents('pysys-run.out', tail=True)
+
+		self.pysys.pysys('pysys-disabledperf', ['run', '-o', self.output+'/myoutdir-disabled', '-XdisablePerformanceReporting'], workingDir=self.input)
 		
 	def validate(self):
 		path = self.grep('pysys-run.out', 'Creating performance summary log file at: (.+)')
@@ -30,3 +32,6 @@ class PySysTest(pysys.basetest.BaseTest):
 		self.assertDiff(self.copy('pysys-run.out', 'perf-summary.out', mappers=[
 			pysys.mappers.IncludeLinesBetween(startAfter='Performance results summary:', stopBefore=' (INFO|CRIT) *$'),
 		]))
+
+		self.assertGrep('pysys-disabledperf.out', 'Creating performance summary log file at: ', contains=False)
+		self.assertGrep('pysys-disabledperf.out', 'Not recording performance result due to disablePerformanceReporting.*')

--- a/test/correctness/PySys_internal_179/Input/MyNestedTestcase/pysystest.py
+++ b/test/correctness/PySys_internal_179/Input/MyNestedTestcase/pysystest.py
@@ -1,0 +1,16 @@
+__pysys_title__   = r""" Nested """ 
+#                        ================================================================================
+
+import pysys
+from pysys.constants import *
+
+import os, sys, math, shutil, glob
+
+class PySysTest(pysys.basetest.BaseTest):
+
+	def execute(self):
+		self.reportPerformanceResult(1000+(self.testCycle+1)*10, 'Rate of doing a foo bar', '/s')
+		self.reportPerformanceResult(2000+(self.testCycle+1), 'Rate of doing a badda-badda-bing', '/s')
+		
+	def validate(self):
+		self.addOutcome(PASSED)

--- a/test/correctness/PySys_internal_179/Input/MyNestedTestcase/pysystest.py
+++ b/test/correctness/PySys_internal_179/Input/MyNestedTestcase/pysystest.py
@@ -1,5 +1,6 @@
 __pysys_title__   = r""" Nested """ 
 #                        ================================================================================
+__pysys_modes__ = "lambda helper: {'MyMode': {'ModeParamA':123, 'ModeParamB':'Foo'}}"
 
 import pysys
 from pysys.constants import *

--- a/test/correctness/PySys_internal_179/Input/pysysproject.xml
+++ b/test/correctness/PySys_internal_179/Input/pysysproject.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" standalone="yes"?>
+<pysysproject>
+	<!--
+	<pysysdirconfig>
+	</pysysdirconfig>
+	-->
+	
+	<performance-reporters>
+	
+		<performance-reporter classname="pysys.utils.perfreporter.CSVPerformanceReporter">
+			<property name="aggregateCycles" value="true"/>
+			<property name="summaryFile" value="__pysys_performance/${outDirName}/perf_${outDirName}.csv"/>
+		</performance-reporter>
+		
+		<performance-reporter classname="pysys.utils.perfreporter.JSONPerformanceReporter"
+			summaryFile="__pysys_performance/${outDirName}/perf_${outDirName}.json"
+		/>
+		
+	</performance-reporters>
+
+	<default-file-encodings>
+		<default-file-encoding pattern="run.log" encoding="utf-8"/>
+		
+		<default-file-encoding pattern="*.xml" encoding="utf-8"/>
+		<default-file-encoding pattern="*.json" encoding="utf-8"/>
+		<default-file-encoding pattern="*.yaml" encoding="utf-8"/>
+		
+	</default-file-encodings>	
+	
+	
+	
+</pysysproject>

--- a/test/correctness/PySys_internal_179/Input/pysysproject.xml
+++ b/test/correctness/PySys_internal_179/Input/pysysproject.xml
@@ -15,6 +15,10 @@
 		<performance-reporter classname="pysys.utils.perfreporter.JSONPerformanceReporter"
 			summaryFile="__pysys_performance/${outDirName}/perf_${outDirName}.json"
 		/>
+
+		<performance-reporter classname="pysys.utils.perfreporter.PrintSummaryPerformanceReporter"
+			summaryFile="__pysys_performance/${outDirName}/perf_${outDirName}.json"
+		/>
 		
 	</performance-reporters>
 

--- a/test/correctness/PySys_internal_179/pysystest.py
+++ b/test/correctness/PySys_internal_179/pysystest.py
@@ -34,3 +34,6 @@ class PySysTest(pysys.basetest.BaseTest):
 			data = json.load(f)
 			self.assertThat('keys == expected', keys=sorted(list(data.keys())), expected=sorted(['runDetails', 'results']))
 			self.assertThat('runDetails and results', runDetails=data['runDetails'], results=data['results'])
+			self.assertThat('resultDetails == expected', resultDetails=data['results'][0]['resultDetails'], expected={
+				'mode': 'MyMode', 'ModeParamA': 123, 'ModeParamB': 'Foo'
+			})

--- a/test/correctness/PySys_internal_179/pysystest.py
+++ b/test/correctness/PySys_internal_179/pysystest.py
@@ -1,0 +1,36 @@
+__pysys_title__   = r""" PerformanceReporter - JSON""" 
+#                        ================================================================================
+
+__pysys_purpose__ = r""" 
+	
+	""" 
+	
+__pysys_authors__ = "bsp"
+__pysys_created__ = "2022-02-04"
+
+#__pysys_traceability_ids__ = "Bug-1234, UserStory-456" 
+#__pysys_groups__           = "myGroup, disableCoverage, performance; inherit=true"
+#__pysys_skipped_reason__   = "Skipped until Bug-1234 is fixed"
+#__pysys_modes__            = """ lambda helper: helper.combineModeDimensions(helper.inheritedModes, helper.makeAllPrimary({'MyMode':{'MyParam':123}})) """
+
+import pysys
+from pysys.constants import *
+import json
+
+from pysys.utils.perfreporter import CSVPerformanceFile
+
+import os, sys, math, shutil, glob
+
+class PySysTest(pysys.basetest.BaseTest):
+
+	def execute(self):
+		self.pysys.pysys('pysys-run', ['run', '-o', self.output+'/myoutdir', '--cycle=3'], workingDir=self.input)
+		self.logFileContents('pysys-run.out', tail=True)
+		
+	def validate(self):
+		path = self.grep('pysys-run.out', 'Creating performance summary log file at: (.+json)')
+		self.logFileContents(path)
+		with open(path, encoding='utf-8') as f:
+			data = json.load(f)
+			self.assertThat('keys == expected', keys=sorted(list(data.keys())), expected=sorted(['runDetails', 'results']))
+			self.assertThat('runDetails and results', runDetails=data['runDetails'], results=data['results'])

--- a/test/correctness/PySys_internal_180/Input/MyNestedTestcase/pysystest.py
+++ b/test/correctness/PySys_internal_180/Input/MyNestedTestcase/pysystest.py
@@ -1,8 +1,6 @@
 __pysys_title__   = r""" Nested """ 
 #                        ================================================================================
 
-__pysys_modes__ = "lambda helper: {'MyMode': {}}"
-
 import pysys
 from pysys.constants import *
 

--- a/test/correctness/PySys_internal_180/Input/pysysproject.xml
+++ b/test/correctness/PySys_internal_180/Input/pysysproject.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" standalone="yes"?>
+<pysysproject>
+	<!--
+	<pysysdirconfig>
+	</pysysdirconfig>
+	-->
+
+	<performance-reporters>
+	
+		<performance-reporter classname="pysys.utils.perfreporter.CSVPerformanceReporter">
+			<property name="aggregateCycles" value="true"/>
+			<property name="summaryFile" value="__pysys_performance/${outDirName}/perf_${outDirName}.csv"/>
+		</performance-reporter>
+				
+	</performance-reporters>
+
+	<default-file-encodings>
+		<default-file-encoding pattern="run.log" encoding="utf-8"/>
+		
+		<default-file-encoding pattern="*.xml" encoding="utf-8"/>
+		<default-file-encoding pattern="*.json" encoding="utf-8"/>
+		<default-file-encoding pattern="*.yaml" encoding="utf-8"/>
+		
+	</default-file-encodings>	
+	
+</pysysproject>

--- a/test/correctness/PySys_internal_180/pysystest.py
+++ b/test/correctness/PySys_internal_180/pysystest.py
@@ -1,0 +1,30 @@
+__pysys_title__   = r""" PerformanceReporter - CSV multi-cycle aggregation""" 
+#                        ================================================================================
+
+__pysys_purpose__ = r""" 
+	
+	""" 
+	
+__pysys_authors__ = "bsp"
+__pysys_created__ = "2022-02-04"
+
+import pysys
+from pysys.constants import *
+
+from pysys.utils.perfreporter import CSVPerformanceFile
+
+import os, sys, math, shutil, glob
+
+class PySysTest(pysys.basetest.BaseTest):
+
+	def execute(self):
+		self.pysys.pysys('pysys-run', ['run', '-o', self.output+'/myoutdir', '--cycle=3'], workingDir=self.input)
+		self.logFileContents('pysys-run.out', tail=True)
+		
+	def validate(self):
+		path = self.grep('pysys-run.out', 'Creating performance summary log file at: (.+)')
+		f = CSVPerformanceFile.load(path)
+		self.assertThat('len(runDetails) > 0', runDetails=f.runDetails) # not empty
+		self.assertThat('resultsLen == expected', resultsLen=len(f.results), expected=2)
+		self.assertThat('result1samples == expected', result1samples=f.results[0]['samples'], expected=3)
+		self.assertThat('result2stdDev == expected', result2stdDev=f.results[-1]['stdDev'], expected=10.0)

--- a/test/correctness/PySys_internal_181/Input/MyNestedTestcase/pysystest.py
+++ b/test/correctness/PySys_internal_181/Input/MyNestedTestcase/pysystest.py
@@ -1,0 +1,16 @@
+__pysys_title__   = r""" Nested """ 
+#                        ================================================================================
+
+import pysys
+from pysys.constants import *
+
+import os, sys, math, shutil, glob
+
+class PySysTest(pysys.basetest.BaseTest):
+
+	def execute(self):
+		self.reportPerformanceResult(1000+(self.testCycle+1)*10, 'Rate of doing a foo bar', '/s')
+		self.reportPerformanceResult(2000+(self.testCycle+1), 'Rate of doing a badda-badda-bing', '/s')
+		
+	def validate(self):
+		self.addOutcome(PASSED)

--- a/test/correctness/PySys_internal_181/Input/__pysys_performance/win_myhost/perf_2022-02-05_14.08.51.win.csv
+++ b/test/correctness/PySys_internal_181/Input/__pysys_performance/win_myhost/perf_2022-02-05_14.08.51.win.csv
@@ -1,4 +1,4 @@
-# resultKey,testId,value,unit,biggerIsBetter,toleranceStdDevs,samples,stdDev,#runDetails:#,outDirName=historicOutDir,hostname=orighost,cpuCount=12,os=Windows 10 10.0.19043 SP0,startTime=2022-02-05 14:08:51; 2022-02-06 15:08:51; 2022-02-07 16:00:00
+# resultKey,testId,value,unit,biggerIsBetter,toleranceStdDevs,samples,stdDev,#runDetails:#,outDirName=myoutdir,hostname=orighost,cpuCount=12,os=Windows 10 10.0.19043 SP0,startTime=2022-02-05 14:08:51; 2022-02-06 15:08:51; 2022-02-07 16:00:00
 Rate of doing a badda-badda-bing,MyNestedTestcase,1500,/s,True,0.0,2,123.4
 Rate of doing a foo bar,MyNestedTestcase,1000.0,/s,True,0.0,1,0
 Rate of doing a foo bar,MyNestedTestcase,1500.0,/s,True,0.0,1,0

--- a/test/correctness/PySys_internal_181/Input/__pysys_performance/win_myhost/perf_2022-02-05_14.08.51.win.csv
+++ b/test/correctness/PySys_internal_181/Input/__pysys_performance/win_myhost/perf_2022-02-05_14.08.51.win.csv
@@ -1,0 +1,5 @@
+# resultKey,testId,value,unit,biggerIsBetter,toleranceStdDevs,samples,stdDev,#runDetails:#,outDirName=historicOutDir,hostname=orighost,cpuCount=12,os=Windows 10 10.0.19043 SP0,startTime=2022-02-05 14:08:51; 2022-02-06 15:08:51; 2022-02-07 16:00:00
+Rate of doing a badda-badda-bing,MyNestedTestcase,1500,/s,True,0.0,2,123.4
+Rate of doing a foo bar,MyNestedTestcase,1000.0,/s,True,0.0,1,0
+Rate of doing a foo bar,MyNestedTestcase,1500.0,/s,True,0.0,1,0
+Rate of doing an extra thing this test doesn't do,MyNestedTestcase,1025.0,/s,True,0.0,2,7.0710678118654755

--- a/test/correctness/PySys_internal_181/Input/__pysys_performance/win_myhost/perf_myoutdir.json
+++ b/test/correctness/PySys_internal_181/Input/__pysys_performance/win_myhost/perf_myoutdir.json
@@ -1,0 +1,5 @@
+{"runDetails": {"outDirName": "historicOutDir", "hostname": "myjsonhost", "cpuCount": "12", "os": "Windows 10 10.0.19043 SP0", "startTime": "2022-02-05 18:38:03"}, "results":[
+{"resultKey": "Rate of doing a badda-badda-bing", "value": 2010, "unit": "/s", "biggerIsBetter": true, "samples": 1, "stdDev": 0, "toleranceStdDevs": null, "testId": "MyNestedTestcase", "resultDetails": {}},
+{"resultKey": "Rate of doing a badda-badda-bing", "value": 2020, "unit": "/s", "biggerIsBetter": true, "samples": 1, "stdDev": 0, "toleranceStdDevs": null, "testId": "MyNestedTestcase", "resultDetails": {}},
+{"resultKey": "Rate of doing a badda-badda-bing", "value": 2040, "unit": "/s", "biggerIsBetter": true, "samples": 1, "stdDev": 0, "toleranceStdDevs": null, "testId": "MyNestedTestcase", "resultDetails": {}}
+]}

--- a/test/correctness/PySys_internal_181/Input/__pysys_performance/win_myhost/perf_myoutdir.json
+++ b/test/correctness/PySys_internal_181/Input/__pysys_performance/win_myhost/perf_myoutdir.json
@@ -1,4 +1,32 @@
 {"runDetails": {"outDirName": "historicOutDir", "hostname": "myjsonhost", "cpuCount": "100", "os": "Windows 10 10.0.19043 SP0", "startTime": "2022-02-05 18:38:03"}, "results":[
+
+{"resultKey": "Time expected to get higher/worse by 10%", "value": 10500000130, "unit": "ns", "biggerIsBetter": false, "samples": 1, "stdDev": 0, "toleranceStdDevs": null, "testId": "Synthetic", "resultDetails": {}},
+{"resultKey": "Time expected to get higher/worse by 10%", "value": 9500000117, "unit": "ns", "biggerIsBetter": false, "samples": 1, "stdDev": 0, "toleranceStdDevs": null, "testId": "Synthetic", "resultDetails": {}},
+
+{"resultKey": "Time expected to get higher/worse by 4x", "value": 10500000130, "unit": "ns", "biggerIsBetter": false, "samples": 1, "stdDev": 0, "toleranceStdDevs": null, "testId": "Synthetic", "resultDetails": {}},
+{"resultKey": "Time expected to get higher/worse by 4x", "value": 9500000117, "unit": "ns", "biggerIsBetter": false, "samples": 1, "stdDev": 0, "toleranceStdDevs": null, "testId": "Synthetic", "resultDetails": {}},
+
+{"resultKey": "Time expected to get lower/better by 10%", "value": 10500000130, "unit": "ns", "biggerIsBetter": false, "samples": 1, "stdDev": 0, "toleranceStdDevs": null, "testId": "Synthetic", "resultDetails": {}},
+{"resultKey": "Time expected to get lower/better by 10%", "value": 9500000117, "unit": "ns", "biggerIsBetter": false, "samples": 1, "stdDev": 0, "toleranceStdDevs": null, "testId": "Synthetic", "resultDetails": {}},
+
+{"resultKey": "Time expected to get lower/better by 75%", "value": 10500000130, "unit": "ns", "biggerIsBetter": false, "samples": 1, "stdDev": 0, "toleranceStdDevs": null, "testId": "Synthetic", "resultDetails": {}},
+{"resultKey": "Time expected to get lower/better by 75%", "value": 9500000117, "unit": "ns", "biggerIsBetter": false, "samples": 1, "stdDev": 0, "toleranceStdDevs": null, "testId": "Synthetic", "resultDetails": {}},
+
+{"resultKey": "Time expected to get higher/worse by 1000x", "value": 10000000123, "unit": "ns", "biggerIsBetter": false, "samples": 1, "stdDev": 0, "toleranceStdDevs": null, "testId": "Synthetic", "resultDetails": {}},
+{"resultKey": "Time expected to get lower/better by 1/1000x", "value": 10000000123, "unit": "ns", "biggerIsBetter": false, "samples": 1, "stdDev": 0, "toleranceStdDevs": null, "testId": "Synthetic", "resultDetails": {}},
+
+{"resultKey": "Small time expected to get higher/worse by 1000x", "value": 0.0000234, "unit": "s", "biggerIsBetter": false, "samples": 1, "stdDev": 0, "toleranceStdDevs": null, "testId": "Synthetic", "resultDetails": {}},
+{"resultKey": "Small time expected to get lower/better by 1/1000x", "value": 0.0000234, "unit": "s", "biggerIsBetter": false, "samples": 1, "stdDev": 0, "toleranceStdDevs": null, "testId": "Synthetic", "resultDetails": {}},
+
+
+{"resultKey": "Rate expected to get higher/better by 10%", "value": 1000123, "unit": "/s", "biggerIsBetter": true, "samples": 1, "stdDev": 0, "toleranceStdDevs": null, "testId": "Synthetic", "resultDetails": {}},
+{"resultKey": "Rate expected to get higher/better by 1000x", "value": 1000123, "unit": "/s", "biggerIsBetter": true, "samples": 1, "stdDev": 0, "toleranceStdDevs": null, "testId": "Synthetic", "resultDetails": {}},
+{"resultKey": "Rate expected to get lower/worse by 10%", "value": 1000123, "unit": "/s", "biggerIsBetter": true, "samples": 1, "stdDev": 0, "toleranceStdDevs": null, "testId": "Synthetic", "resultDetails": {}},
+{"resultKey": "Rate expected to get lower/worse by 1/1000x", "value": 1000123, "unit": "/s", "biggerIsBetter": true, "samples": 1, "stdDev": 0, "toleranceStdDevs": null, "testId": "Synthetic", "resultDetails": {}},
+
+{"resultKey": "Small rate expected to get higher/better by 1000x", "value": 0.0000234, "unit": "/s", "biggerIsBetter": true, "samples": 1, "stdDev": 0, "toleranceStdDevs": null, "testId": "Synthetic", "resultDetails": {}},
+{"resultKey": "Small rate expected to get lower/worse by 1/1000x", "value": 0.0000234, "unit": "/s", "biggerIsBetter": true, "samples": 1, "stdDev": 0, "toleranceStdDevs": null, "testId": "Synthetic", "resultDetails": {}},
+
 {"resultKey": "Rate of doing a badda-badda-bing", "value": 2010, "unit": "/s", "biggerIsBetter": true, "samples": 1, "stdDev": 0, "toleranceStdDevs": null, "testId": "MyNestedTestcase", "resultDetails": {}},
 {"resultKey": "Rate of doing a badda-badda-bing", "value": 2020, "unit": "/s", "biggerIsBetter": true, "samples": 1, "stdDev": 0, "toleranceStdDevs": null, "testId": "MyNestedTestcase", "resultDetails": {}},
 {"resultKey": "Rate of doing a badda-badda-bing", "value": 2040, "unit": "/s", "biggerIsBetter": true, "samples": 1, "stdDev": 0, "toleranceStdDevs": null, "testId": "MyNestedTestcase", "resultDetails": {}}

--- a/test/correctness/PySys_internal_181/Input/__pysys_performance/win_myhost/perf_myoutdir.json
+++ b/test/correctness/PySys_internal_181/Input/__pysys_performance/win_myhost/perf_myoutdir.json
@@ -1,4 +1,4 @@
-{"runDetails": {"outDirName": "historicOutDir", "hostname": "myjsonhost", "cpuCount": "12", "os": "Windows 10 10.0.19043 SP0", "startTime": "2022-02-05 18:38:03"}, "results":[
+{"runDetails": {"outDirName": "historicOutDir", "hostname": "myjsonhost", "cpuCount": "100", "os": "Windows 10 10.0.19043 SP0", "startTime": "2022-02-05 18:38:03"}, "results":[
 {"resultKey": "Rate of doing a badda-badda-bing", "value": 2010, "unit": "/s", "biggerIsBetter": true, "samples": 1, "stdDev": 0, "toleranceStdDevs": null, "testId": "MyNestedTestcase", "resultDetails": {}},
 {"resultKey": "Rate of doing a badda-badda-bing", "value": 2020, "unit": "/s", "biggerIsBetter": true, "samples": 1, "stdDev": 0, "toleranceStdDevs": null, "testId": "MyNestedTestcase", "resultDetails": {}},
 {"resultKey": "Rate of doing a badda-badda-bing", "value": 2040, "unit": "/s", "biggerIsBetter": true, "samples": 1, "stdDev": 0, "toleranceStdDevs": null, "testId": "MyNestedTestcase", "resultDetails": {}}

--- a/test/correctness/PySys_internal_181/Input/perf_run3.json
+++ b/test/correctness/PySys_internal_181/Input/perf_run3.json
@@ -1,7 +1,35 @@
 {"runDetails": {"outDirName": "historicOutDir", "hostname": "myjsonhost", "cpuCount": "12", "os": "Windows 10 10.0.19043 SP0", "startTime": "2022-02-05 18:38:03"}, "results":[
-{"resultKey": "Rate of doing a badda-badda-bing", "value": 200000000000, "unit": "/s", "biggerIsBetter": true, "samples": 1, "stdDev": 0, "toleranceStdDevs": null, "testId": "MyNestedTestcase", "resultDetails": {}},
+
+{"resultKey": "Time expected to get higher/worse by 10%", "value": 11550000143.45, "unit": "ns", "biggerIsBetter": false, "samples": 1, "stdDev": 0, "toleranceStdDevs": 1.1, "testId": "Synthetic", "resultDetails": {}},
+{"resultKey": "Time expected to get higher/worse by 10%", "value": 10450000129.12, "unit": "ns", "biggerIsBetter": false, "samples": 1, "stdDev": 0, "toleranceStdDevs": 1.1, "testId": "Synthetic", "resultDetails": {}},
+
+{"resultKey": "Time expected to get higher/worse by 4x", "value": 42000000519.45, "unit": "ns", "biggerIsBetter": false, "samples": 1, "stdDev": 0, "toleranceStdDevs": null, "testId": "Synthetic", "resultDetails": {}},
+{"resultKey": "Time expected to get higher/worse by 4x", "value": 38000000469.12, "unit": "ns", "biggerIsBetter": false, "samples": 1, "stdDev": 0, "toleranceStdDevs": null, "testId": "Synthetic", "resultDetails": {}},
+
+{"resultKey": "Time expected to get lower/better by 10%", "value": 9450000117.45, "unit": "ns", "biggerIsBetter": false, "samples": 1, "stdDev": 0, "toleranceStdDevs": null, "testId": "Synthetic", "resultDetails": {}},
+{"resultKey": "Time expected to get lower/better by 10%", "value": 8550000106.12, "unit": "ns", "biggerIsBetter": false, "samples": 1, "stdDev": 0, "toleranceStdDevs": null, "testId": "Synthetic", "resultDetails": {}},
+
+{"resultKey": "Time expected to get lower/better by 75%", "value": 2625000032.45, "unit": "ns", "biggerIsBetter": false, "samples": 1, "stdDev": 0, "toleranceStdDevs": null, "testId": "Synthetic", "resultDetails": {}},
+{"resultKey": "Time expected to get lower/better by 75%", "value": 2375000029.12, "unit": "ns", "biggerIsBetter": false, "samples": 1, "stdDev": 0, "toleranceStdDevs": null, "testId": "Synthetic", "resultDetails": {}},
+
+{"resultKey": "Time expected to get higher/worse by 1000x", "value": 10000000123000, "unit": "ns", "biggerIsBetter": false, "samples": 1, "stdDev": 0, "toleranceStdDevs": null, "testId": "Synthetic", "resultDetails": {}},
+{"resultKey": "Time expected to get lower/better by 1/1000x", "value": 10000123, "unit": "ns", "biggerIsBetter": false, "samples": 1, "stdDev": 0, "toleranceStdDevs": null, "testId": "Synthetic", "resultDetails": {}},
+
+{"resultKey": "Small time expected to get higher/worse by 1000x", "value": 0.0234, "unit": "s", "biggerIsBetter": false, "samples": 1, "stdDev": 0, "toleranceStdDevs": null, "testId": "Synthetic", "resultDetails": {}},
+{"resultKey": "Small time expected to get lower/better by 1/1000x", "value": 0.0000000234, "unit": "s", "biggerIsBetter": false, "samples": 1, "stdDev": 0, "toleranceStdDevs": null, "testId": "Synthetic", "resultDetails": {}},
+
+{"resultKey": "Rate expected to get higher/better by 10%", "value": 1100135.3, "unit": "/s", "biggerIsBetter": true, "samples": 1, "stdDev": 0, "toleranceStdDevs": null, "testId": "Synthetic", "resultDetails": {}},
+{"resultKey": "Rate expected to get higher/better by 1000x", "value": 1000123000, "unit": "/s", "biggerIsBetter": true, "samples": 1, "stdDev": 0, "toleranceStdDevs": null, "testId": "Synthetic", "resultDetails": {}},
+{"resultKey": "Rate expected to get lower/worse by 10%", "value": 900110.7, "unit": "/s", "biggerIsBetter": true, "samples": 1, "stdDev": 0, "toleranceStdDevs": null, "testId": "Synthetic", "resultDetails": {}},
+{"resultKey": "Rate expected to get lower/worse by 1/1000x", "value": 900.1107, "unit": "/s", "biggerIsBetter": true, "samples": 1, "stdDev": 0, "toleranceStdDevs": null, "testId": "Synthetic", "resultDetails": {}},
+
+{"resultKey": "Small rate expected to get higher/better by 1000x", "value": 0.0234, "unit": "/s", "biggerIsBetter": true, "samples": 1, "stdDev": 0, "toleranceStdDevs": null, "testId": "Synthetic", "resultDetails": {}},
+{"resultKey": "Small rate expected to get lower/worse by 1/1000x", "value": 0.0000000234, "unit": "/s", "biggerIsBetter": true, "samples": 1, "stdDev": 0, "toleranceStdDevs": null, "testId": "Synthetic", "resultDetails": {}},
+
+
+{"resultKey": "Rate of doing a badda-badda-bing", "value": 2000, "unit": "/s", "biggerIsBetter": true, "samples": 1, "stdDev": 0, "toleranceStdDevs": null, "testId": "MyNestedTestcase", "resultDetails": {}},
 {"resultKey": "Rate of doing a badda-badda-bing", "value": 2020, "unit": "/s", "biggerIsBetter": true, "samples": 1, "stdDev": 0, "toleranceStdDevs": null, "testId": "MyNestedTestcase", "resultDetails": {}},
-{"resultKey": "Rate of doing a badda-badda-bing", "value": 0.0000000001, "unit": "/s", "biggerIsBetter": true, "samples": 1, "stdDev": 0, "toleranceStdDevs": null, "testId": "MyNestedTestcase", "resultDetails": {}},
+{"resultKey": "Rate of doing a badda-badda-bing", "value": 0.000001, "unit": "/s", "biggerIsBetter": true, "samples": 1, "stdDev": 0, "toleranceStdDevs": null, "testId": "MyNestedTestcase", "resultDetails": {}},
 {"resultKey": "Rate of doing a foo bar", "value": 20000000001, "unit": "/s", "biggerIsBetter": true, "samples": 1, "stdDev": 0, "toleranceStdDevs": null, "testId": "MyNestedTestcase", "resultDetails": {}},
 {"resultKey": "Rate of doing a foo bar", "value": 20000000021, "unit": "/s", "biggerIsBetter": true, "samples": 1, "stdDev": 0, "toleranceStdDevs": null, "testId": "MyNestedTestcase", "resultDetails": {}}
 ]}

--- a/test/correctness/PySys_internal_181/Input/perf_run3.json
+++ b/test/correctness/PySys_internal_181/Input/perf_run3.json
@@ -1,4 +1,4 @@
-{"runDetails": {"outDirName": "historicOutDir", "hostname": "myjsonhost", "cpuCount": "12", "os": "Windows 10 10.0.19043 SP0", "startTime": "2022-02-05 18:38:03"}, "results":[
+{"runDetails": {"outDirName": "newOutDir", "hostname": "myjsonhost", "cpuCount": "12", "os": "Windows 10 10.0.19043 SP0", "startTime": "2022-02-05 18:38:03"}, "results":[
 
 {"resultKey": "Time expected to get higher/worse by 10%", "value": 11550000143.45, "unit": "ns", "biggerIsBetter": false, "samples": 1, "stdDev": 0, "toleranceStdDevs": 1.1, "testId": "Synthetic", "resultDetails": {}},
 {"resultKey": "Time expected to get higher/worse by 10%", "value": 10450000129.12, "unit": "ns", "biggerIsBetter": false, "samples": 1, "stdDev": 0, "toleranceStdDevs": 1.1, "testId": "Synthetic", "resultDetails": {}},

--- a/test/correctness/PySys_internal_181/Input/perf_run3.json
+++ b/test/correctness/PySys_internal_181/Input/perf_run3.json
@@ -1,0 +1,7 @@
+{"runDetails": {"outDirName": "historicOutDir", "hostname": "myjsonhost", "cpuCount": "12", "os": "Windows 10 10.0.19043 SP0", "startTime": "2022-02-05 18:38:03"}, "results":[
+{"resultKey": "Rate of doing a badda-badda-bing", "value": 200000000000, "unit": "/s", "biggerIsBetter": true, "samples": 1, "stdDev": 0, "toleranceStdDevs": null, "testId": "MyNestedTestcase", "resultDetails": {}},
+{"resultKey": "Rate of doing a badda-badda-bing", "value": 2020, "unit": "/s", "biggerIsBetter": true, "samples": 1, "stdDev": 0, "toleranceStdDevs": null, "testId": "MyNestedTestcase", "resultDetails": {}},
+{"resultKey": "Rate of doing a badda-badda-bing", "value": 0.0000000001, "unit": "/s", "biggerIsBetter": true, "samples": 1, "stdDev": 0, "toleranceStdDevs": null, "testId": "MyNestedTestcase", "resultDetails": {}},
+{"resultKey": "Rate of doing a foo bar", "value": 20000000001, "unit": "/s", "biggerIsBetter": true, "samples": 1, "stdDev": 0, "toleranceStdDevs": null, "testId": "MyNestedTestcase", "resultDetails": {}},
+{"resultKey": "Rate of doing a foo bar", "value": 20000000021, "unit": "/s", "biggerIsBetter": true, "samples": 1, "stdDev": 0, "toleranceStdDevs": null, "testId": "MyNestedTestcase", "resultDetails": {}}
+]}

--- a/test/correctness/PySys_internal_181/Input/pysysproject.xml
+++ b/test/correctness/PySys_internal_181/Input/pysysproject.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" standalone="yes"?>
+<pysysproject>
+	<!--
+	<pysysdirconfig>
+	</pysysdirconfig>
+	-->
+
+	<performance-reporters>
+	
+		<performance-reporter classname="pysys.utils.perfreporter.CSVPerformanceReporter"/>
+		<performance-reporter classname="pysys.utils.perfreporter.JSONPerformanceReporter"/>
+		<performance-reporter classname="pysys.utils.perfreporter.PrintSummaryPerformanceReporter"/>
+				
+	</performance-reporters>
+
+	<default-file-encodings>
+		<default-file-encoding pattern="run.log" encoding="utf-8"/>
+		
+		<default-file-encoding pattern="*.xml" encoding="utf-8"/>
+		<default-file-encoding pattern="*.json" encoding="utf-8"/>
+		<default-file-encoding pattern="*.yaml" encoding="utf-8"/>
+		
+	</default-file-encodings>	
+	
+</pysysproject>

--- a/test/correctness/PySys_internal_181/Reference/perf-compare-no-colors.out
+++ b/test/correctness/PySys_internal_181/Reference/perf-compare-no-colors.out
@@ -1,91 +1,91 @@
 Performance comparison summary between the following runs (the differing "run details" are shown):
-- 2022-02-05_14.08.51.win (3 result keys, 2 samples/result):
-     hostname=orighost, cpuCount=12, startTime=2022-02-05 14:08:51 .. 2022-02-07 16:00:00
-- myoutdir (15 result keys, 1 samples/result):
-     hostname=myjsonhost, cpuCount=100, startTime=2022-02-05 18:38:03
-- run3 (16 result keys, 1 samples/result):
-     hostname=myjsonhost, cpuCount=12, startTime=2022-02-05 18:38:03
+- myoutdir (3 result keys, 2 samples/result) from __pysys_performance/win_myhost/perf_2022-02-05_14.08.51.win.csv:
+     outDirName=myoutdir, hostname=orighost, cpuCount=12, startTime=2022-02-05 14:08:51 .. 2022-02-07 16:00:00
+- historicOutDir (15 result keys, 1 samples/result) from __pysys_performance/win_myhost/perf_myoutdir.json:
+     outDirName=historicOutDir, hostname=myjsonhost, cpuCount=100, startTime=2022-02-05 18:38:03
+- newOutDir (16 result keys, 1 samples/result) from perf_run3.json:
+     outDirName=newOutDir, hostname=myjsonhost, cpuCount=12, startTime=2022-02-05 18:38:03
 
 Comparison results:
   where fromRun->toRun format is: (%improvement) = (speedup ratio) = (sigmas/stdDevs where change above +/- 2.0 gives 95% probability it's significant; only significant results are colored)
 
 Rate expected to get higher/better by 10% from Synthetic
  Mean from this run = 1,100,135 /s
-  2022-02-05_14.08.51.win->run3: Compare from value is missing
-                 myoutdir->run3: +10.0% = 1.1x speedup
+        myoutdir->newOutDir: Compare from value is missing
+  historicOutDir->newOutDir: +10.0% = 1.1x speedup
 
 Rate expected to get higher/better by 1000x from Synthetic
  Mean from this run = 1,000,123,000 /s
-  2022-02-05_14.08.51.win->run3: Compare from value is missing
-                 myoutdir->run3: +99900.0% = 1000x speedup
+        myoutdir->newOutDir: Compare from value is missing
+  historicOutDir->newOutDir: +99900.0% = 1000x speedup
 
 Rate expected to get lower/worse by 1/1000x from Synthetic
  Mean from this run = 900.1 /s
-  2022-02-05_14.08.51.win->run3: Compare from value is missing
-                 myoutdir->run3: -99.9% = 0.0009x speedup
+        myoutdir->newOutDir: Compare from value is missing
+  historicOutDir->newOutDir: -99.9% = 0.0009x speedup
 
 Rate expected to get lower/worse by 10% from Synthetic
  Mean from this run = 900,110 /s
-  2022-02-05_14.08.51.win->run3: Compare from value is missing
-                 myoutdir->run3: -10.0% = 0.9x speedup
+        myoutdir->newOutDir: Compare from value is missing
+  historicOutDir->newOutDir: -10.0% = 0.9x speedup
 
 Rate of doing a badda-badda-bing from MyNestedTestcase
  Mean from this run = 1,340 /s with stdDev=1,160 (86.6% of mean)
-  2022-02-05_14.08.51.win->run3: -10.7% = 0.8933x speedup = -0.1 sigmas
-                 myoutdir->run3: -33.8% = 0.6623x speedup = -0.4 sigmas
+        myoutdir->newOutDir: -10.7% = 0.8933x speedup = -0.1 sigmas
+  historicOutDir->newOutDir: -33.8% = 0.6623x speedup = -0.4 sigmas
 
 Rate of doing a foo bar from MyNestedTestcase
  Mean from this run = 20,000,000,011 /s with stdDev=14.14 (0.0% of mean)
-  2022-02-05_14.08.51.win->run3: +1599999900.9% = 16,000,000x speedup = +56568539.0 sigmas
-                 myoutdir->run3: Compare from value is missing
+        myoutdir->newOutDir: +1599999900.9% = 16,000,000x speedup = +56568539.0 sigmas
+  historicOutDir->newOutDir: Compare from value is missing
 
 Small rate expected to get higher/better by 1000x from Synthetic
  Mean from this run = 0.0234 /s
-  2022-02-05_14.08.51.win->run3: Compare from value is missing
-                 myoutdir->run3: +99900.0% = 1000x speedup
+        myoutdir->newOutDir: Compare from value is missing
+  historicOutDir->newOutDir: +99900.0% = 1000x speedup
 
 Small rate expected to get lower/worse by 1/1000x from Synthetic
  Mean from this run = 0.000000 /s
-  2022-02-05_14.08.51.win->run3: Compare from value is missing
-                 myoutdir->run3: -99.9% = 0.001x speedup
+        myoutdir->newOutDir: Compare from value is missing
+  historicOutDir->newOutDir: -99.9% = 0.001x speedup
 
 Small time expected to get higher/worse by 1000x from Synthetic
  Mean from this run = 0.0234 s
-  2022-02-05_14.08.51.win->run3: Compare from value is missing
-                 myoutdir->run3: -99900.0% = 0.001x speedup
+        myoutdir->newOutDir: Compare from value is missing
+  historicOutDir->newOutDir: -99900.0% = 0.001x speedup
 
 Small time expected to get lower/better by 1/1000x from Synthetic
  Mean from this run = 0.000000 s
-  2022-02-05_14.08.51.win->run3: Compare from value is missing
-                 myoutdir->run3: +99.9% = 1000x speedup
+        myoutdir->newOutDir: Compare from value is missing
+  historicOutDir->newOutDir: +99.9% = 1000x speedup
 
 Time expected to get higher/worse by 10% from Synthetic
  Mean from this run = 11,000,000,136 ns with stdDev=777,817,469 (7.1% of mean); configured toleranceStdDevs=1.1
-  2022-02-05_14.08.51.win->run3: Compare from value is missing
-                 myoutdir->run3: -10.0% = 0.9091x speedup = -1.4 sigmas
+        myoutdir->newOutDir: Compare from value is missing
+  historicOutDir->newOutDir: -10.0% = 0.9091x speedup = -1.4 sigmas
 
 Time expected to get higher/worse by 1000x from Synthetic
  Mean from this run = 10,000,000,123,000 ns
-  2022-02-05_14.08.51.win->run3: Compare from value is missing
-                 myoutdir->run3: -99900.0% = 0.001x speedup
+        myoutdir->newOutDir: Compare from value is missing
+  historicOutDir->newOutDir: -99900.0% = 0.001x speedup
 
 Time expected to get higher/worse by 4x from Synthetic
  Mean from this run = 40,000,000,494 ns with stdDev=2,828,427,160 (7.1% of mean)
-  2022-02-05_14.08.51.win->run3: Compare from value is missing
-                 myoutdir->run3: -300.0% = 0.25x speedup = -42.4 sigmas
+        myoutdir->newOutDir: Compare from value is missing
+  historicOutDir->newOutDir: -300.0% = 0.25x speedup = -42.4 sigmas
 
 Time expected to get lower/better by 1/1000x from Synthetic
  Mean from this run = 10,000,123 ns
-  2022-02-05_14.08.51.win->run3: Compare from value is missing
-                 myoutdir->run3: +99.9% = 1000x speedup
+        myoutdir->newOutDir: Compare from value is missing
+  historicOutDir->newOutDir: +99.9% = 1000x speedup
 
 Time expected to get lower/better by 10% from Synthetic
  Mean from this run = 9,000,000,111 ns with stdDev=636,396,111 (7.1% of mean)
-  2022-02-05_14.08.51.win->run3: Compare from value is missing
-                 myoutdir->run3: +10.0% = 1.111x speedup = +1.4 sigmas
+        myoutdir->newOutDir: Compare from value is missing
+  historicOutDir->newOutDir: +10.0% = 1.111x speedup = +1.4 sigmas
 
 Time expected to get lower/better by 75% from Synthetic
  Mean from this run = 2,500,000,030 ns with stdDev=176,776,697 (7.1% of mean)
-  2022-02-05_14.08.51.win->run3: Compare from value is missing
-                 myoutdir->run3: +75.0% = 4x speedup = +10.6 sigmas
+        myoutdir->newOutDir: Compare from value is missing
+  historicOutDir->newOutDir: +75.0% = 4x speedup = +10.6 sigmas
 

--- a/test/correctness/PySys_internal_181/Reference/perf-compare-no-colors.out
+++ b/test/correctness/PySys_internal_181/Reference/perf-compare-no-colors.out
@@ -7,15 +7,15 @@ Performance comparison summary between the following runs (the differing "run de
      hostname=myjsonhost, startTime=2022-02-05 18:38:03
 
 Comparison results:
-  where format is (fromRun->toRun): (%improvement) = (change above 2 sigmas/stdDevs is 95% probability it's significant)
+  where fromRun->toRun format is: (%improvement) = (speedup ratio) = (sigmas/stdDevs where change above +/- 2.0 gives 95% probability it's significant)
 
 Rate of doing a badda-badda-bing from MyNestedTestcase
  Mean from this run = 66,666,667,340 /s with stdDev=115,470,053,254 (173.2% of mean)
-  2022-02-05_14.08.51.win->run3: +4444444389.3% = +25660012.0 sigmas
-                 myoutdir->run3: +3294892849.3% = +19023073.0 sigmas
+  2022-02-05_14.08.51.win->run3: +4444444389.3% = 44,444,444x speedup = +25660012.0 sigmas
+                 myoutdir->run3: +3294892849.3% = 32,948,929x speedup = +19023073.0 sigmas
 
 Rate of doing a foo bar from MyNestedTestcase
  Mean from this run = 20,000,000,011 /s with stdDev=14.14 (0.0% of mean)
-  2022-02-05_14.08.51.win->run3: +1599999900.9% = +56568539.0 sigmas
+  2022-02-05_14.08.51.win->run3: +1599999900.9% = 16,000,000x speedup = +56568539.0 sigmas
                  myoutdir->run3: Compare from value is missing
 

--- a/test/correctness/PySys_internal_181/Reference/perf-compare-no-colors.out
+++ b/test/correctness/PySys_internal_181/Reference/perf-compare-no-colors.out
@@ -1,0 +1,21 @@
+Performance comparison summary between the following runs (the differing "run details" are shown):
+- 2022-02-05_14.08.51.win (3 result keys, 2 samples/result):
+     hostname=orighost, startTime=2022-02-05 14:08:51 .. 2022-02-07 16:00:00
+- myoutdir (1 result keys, 3 samples/result):
+     hostname=myjsonhost, startTime=2022-02-05 18:38:03
+- run3 (2 result keys, 2 samples/result):
+     hostname=myjsonhost, startTime=2022-02-05 18:38:03
+
+Comparison results:
+  where format is (fromRun->toRun): (%improvement) = (change above 2 sigmas/stdDevs is 95% probability it's significant)
+
+Rate of doing a badda-badda-bing from MyNestedTestcase
+ Mean from this run = 66,666,667,340 /s with stdDev=115,470,053,254 (173.2% of mean)
+  2022-02-05_14.08.51.win->run3: +4444444389.3% = +25660012.0 sigmas
+                 myoutdir->run3: +3294892849.3% = +19023073.0 sigmas
+
+Rate of doing a foo bar from MyNestedTestcase
+ Mean from this run = 20,000,000,011 /s with stdDev=14.14 (0.0% of mean)
+  2022-02-05_14.08.51.win->run3: +1599999900.9% = +56568539.0 sigmas
+                 myoutdir->run3: Compare from value is missing
+

--- a/test/correctness/PySys_internal_181/Reference/perf-compare-no-colors.out
+++ b/test/correctness/PySys_internal_181/Reference/perf-compare-no-colors.out
@@ -1,10 +1,10 @@
 Performance comparison summary between the following runs (the differing "run details" are shown):
 - 2022-02-05_14.08.51.win (3 result keys, 2 samples/result):
-     hostname=orighost, startTime=2022-02-05 14:08:51 .. 2022-02-07 16:00:00
+     hostname=orighost, cpuCount=12, startTime=2022-02-05 14:08:51 .. 2022-02-07 16:00:00
 - myoutdir (1 result keys, 3 samples/result):
-     hostname=myjsonhost, startTime=2022-02-05 18:38:03
+     hostname=myjsonhost, cpuCount=100, startTime=2022-02-05 18:38:03
 - run3 (2 result keys, 2 samples/result):
-     hostname=myjsonhost, startTime=2022-02-05 18:38:03
+     hostname=myjsonhost, cpuCount=12, startTime=2022-02-05 18:38:03
 
 Comparison results:
   where fromRun->toRun format is: (%improvement) = (speedup ratio) = (sigmas/stdDevs where change above +/- 2.0 gives 95% probability it's significant)

--- a/test/correctness/PySys_internal_181/Reference/perf-compare-no-colors.out
+++ b/test/correctness/PySys_internal_181/Reference/perf-compare-no-colors.out
@@ -1,21 +1,91 @@
 Performance comparison summary between the following runs (the differing "run details" are shown):
 - 2022-02-05_14.08.51.win (3 result keys, 2 samples/result):
      hostname=orighost, cpuCount=12, startTime=2022-02-05 14:08:51 .. 2022-02-07 16:00:00
-- myoutdir (1 result keys, 3 samples/result):
+- myoutdir (15 result keys, 1 samples/result):
      hostname=myjsonhost, cpuCount=100, startTime=2022-02-05 18:38:03
-- run3 (2 result keys, 2 samples/result):
+- run3 (16 result keys, 1 samples/result):
      hostname=myjsonhost, cpuCount=12, startTime=2022-02-05 18:38:03
 
 Comparison results:
-  where fromRun->toRun format is: (%improvement) = (speedup ratio) = (sigmas/stdDevs where change above +/- 2.0 gives 95% probability it's significant)
+  where fromRun->toRun format is: (%improvement) = (speedup ratio) = (sigmas/stdDevs where change above +/- 2.0 gives 95% probability it's significant; only significant results are colored)
+
+Rate expected to get higher/better by 10% from Synthetic
+ Mean from this run = 1,100,135 /s
+  2022-02-05_14.08.51.win->run3: Compare from value is missing
+                 myoutdir->run3: +10.0% = 1.1x speedup
+
+Rate expected to get higher/better by 1000x from Synthetic
+ Mean from this run = 1,000,123,000 /s
+  2022-02-05_14.08.51.win->run3: Compare from value is missing
+                 myoutdir->run3: +99900.0% = 1000x speedup
+
+Rate expected to get lower/worse by 1/1000x from Synthetic
+ Mean from this run = 900.1 /s
+  2022-02-05_14.08.51.win->run3: Compare from value is missing
+                 myoutdir->run3: -99.9% = 0.0009x speedup
+
+Rate expected to get lower/worse by 10% from Synthetic
+ Mean from this run = 900,110 /s
+  2022-02-05_14.08.51.win->run3: Compare from value is missing
+                 myoutdir->run3: -10.0% = 0.9x speedup
 
 Rate of doing a badda-badda-bing from MyNestedTestcase
- Mean from this run = 66,666,667,340 /s with stdDev=115,470,053,254 (173.2% of mean)
-  2022-02-05_14.08.51.win->run3: +4444444389.3% = 44,444,444x speedup = +25660012.0 sigmas
-                 myoutdir->run3: +3294892849.3% = 32,948,929x speedup = +19023073.0 sigmas
+ Mean from this run = 1,340 /s with stdDev=1,160 (86.6% of mean)
+  2022-02-05_14.08.51.win->run3: -10.7% = 0.8933x speedup = -0.1 sigmas
+                 myoutdir->run3: -33.8% = 0.6623x speedup = -0.4 sigmas
 
 Rate of doing a foo bar from MyNestedTestcase
  Mean from this run = 20,000,000,011 /s with stdDev=14.14 (0.0% of mean)
   2022-02-05_14.08.51.win->run3: +1599999900.9% = 16,000,000x speedup = +56568539.0 sigmas
                  myoutdir->run3: Compare from value is missing
+
+Small rate expected to get higher/better by 1000x from Synthetic
+ Mean from this run = 0.0234 /s
+  2022-02-05_14.08.51.win->run3: Compare from value is missing
+                 myoutdir->run3: +99900.0% = 1000x speedup
+
+Small rate expected to get lower/worse by 1/1000x from Synthetic
+ Mean from this run = 0.000000 /s
+  2022-02-05_14.08.51.win->run3: Compare from value is missing
+                 myoutdir->run3: -99.9% = 0.001x speedup
+
+Small time expected to get higher/worse by 1000x from Synthetic
+ Mean from this run = 0.0234 s
+  2022-02-05_14.08.51.win->run3: Compare from value is missing
+                 myoutdir->run3: -99900.0% = 0.001x speedup
+
+Small time expected to get lower/better by 1/1000x from Synthetic
+ Mean from this run = 0.000000 s
+  2022-02-05_14.08.51.win->run3: Compare from value is missing
+                 myoutdir->run3: +99.9% = 1000x speedup
+
+Time expected to get higher/worse by 10% from Synthetic
+ Mean from this run = 11,000,000,136 ns with stdDev=777,817,469 (7.1% of mean); configured toleranceStdDevs=1.1
+  2022-02-05_14.08.51.win->run3: Compare from value is missing
+                 myoutdir->run3: -10.0% = 0.9091x speedup = -1.4 sigmas
+
+Time expected to get higher/worse by 1000x from Synthetic
+ Mean from this run = 10,000,000,123,000 ns
+  2022-02-05_14.08.51.win->run3: Compare from value is missing
+                 myoutdir->run3: -99900.0% = 0.001x speedup
+
+Time expected to get higher/worse by 4x from Synthetic
+ Mean from this run = 40,000,000,494 ns with stdDev=2,828,427,160 (7.1% of mean)
+  2022-02-05_14.08.51.win->run3: Compare from value is missing
+                 myoutdir->run3: -300.0% = 0.25x speedup = -42.4 sigmas
+
+Time expected to get lower/better by 1/1000x from Synthetic
+ Mean from this run = 10,000,123 ns
+  2022-02-05_14.08.51.win->run3: Compare from value is missing
+                 myoutdir->run3: +99.9% = 1000x speedup
+
+Time expected to get lower/better by 10% from Synthetic
+ Mean from this run = 9,000,000,111 ns with stdDev=636,396,111 (7.1% of mean)
+  2022-02-05_14.08.51.win->run3: Compare from value is missing
+                 myoutdir->run3: +10.0% = 1.111x speedup = +1.4 sigmas
+
+Time expected to get lower/better by 75% from Synthetic
+ Mean from this run = 2,500,000,030 ns with stdDev=176,776,697 (7.1% of mean)
+  2022-02-05_14.08.51.win->run3: Compare from value is missing
+                 myoutdir->run3: +75.0% = 4x speedup = +10.6 sigmas
 

--- a/test/correctness/PySys_internal_181/Reference/perf-summary.out
+++ b/test/correctness/PySys_internal_181/Reference/perf-summary.out
@@ -1,0 +1,21 @@
+Performance comparison summary between the following runs (the differing "run details" are shown):
+- 2022-02-05_14.08.51.win (4 results, 1 samples/result):
+     outDirName=historicOutDir, hostname=orighost, startTime=2022-02-05 14:08:51 .. 2022-02-07 16:00:00
+- myoutdir (3 results, 1 samples/result):
+     outDirName=historicOutDir, hostname=myjsonhost, startTime=2022-02-05 18:38:03
+- this (2 results, 3 samples/result):
+     outDirName=myoutdir, <stripped>
+
+Comparison results:
+  where format is (fromRun->toRun): (%improvement) = (change above 2 sigmas/stdDevs is 95% probability it's significant)
+
+Rate of doing a badda-badda-bing from MyNestedTestcase
+ Mean from this run = 2,003 /s, stdDev=1 (0.0% of mean)
+  2022-02-05_14.08.51.win->this: +33.5% = +4.1 sigmas
+                 myoutdir->this:  -1.8% = -36.3 sigmas
+
+Rate of doing a foo bar from MyNestedTestcase
+ Mean from this run = 1,030 /s, stdDev=10 (1.0% of mean)
+  2022-02-05_14.08.51.win->this: -31.3% = -32.3 sigmas
+                 myoutdir->this: Compare from value is missing
+

--- a/test/correctness/PySys_internal_181/Reference/perf-summary.out
+++ b/test/correctness/PySys_internal_181/Reference/perf-summary.out
@@ -1,8 +1,8 @@
 Performance comparison summary between the following runs (the differing "run details" are shown):
 - 2022-02-05_14.08.51.win (3 result keys, 2 samples/result):
-     outDirName=historicOutDir, hostname=orighost, startTime=2022-02-05 14:08:51 .. 2022-02-07 16:00:00
+     outDirName=historicOutDir, <stripped>
 - myoutdir (1 result keys, 3 samples/result):
-     outDirName=historicOutDir, hostname=myjsonhost, startTime=2022-02-05 18:38:03
+     outDirName=historicOutDir, <stripped>
 - this (2 result keys, 3 samples/result):
      outDirName=myoutdir, <stripped>
 

--- a/test/correctness/PySys_internal_181/Reference/perf-summary.out
+++ b/test/correctness/PySys_internal_181/Reference/perf-summary.out
@@ -1,6 +1,6 @@
 Performance comparison summary between the following runs (the differing "run details" are shown):
 - 2022-02-05_14.08.51.win (3 result keys, 2 samples/result):
-     outDirName=historicOutDir, <stripped>
+     outDirName=myoutdir, <stripped>
 - myoutdir (15 result keys, 1 samples/result):
      outDirName=historicOutDir, <stripped>
 - this (2 result keys, 3 samples/result):

--- a/test/correctness/PySys_internal_181/Reference/perf-summary.out
+++ b/test/correctness/PySys_internal_181/Reference/perf-summary.out
@@ -7,15 +7,15 @@ Performance comparison summary between the following runs (the differing "run de
      outDirName=myoutdir, <stripped>
 
 Comparison results:
-  where format is (fromRun->toRun): (%improvement) = (change above 2 sigmas/stdDevs is 95% probability it's significant)
+  where fromRun->toRun format is: (%improvement) = (speedup ratio) = (sigmas/stdDevs where change above +/- 2.0 gives 95% probability it's significant)
 
 Rate of doing a badda-badda-bing from MyNestedTestcase
  Mean from this run = 2,003 /s with stdDev=1 (0.0% of mean)
-  2022-02-05_14.08.51.win->this: +33.5% = +4.1 sigmas
-                 myoutdir->this:  -1.0% = -1.3 sigmas
+  2022-02-05_14.08.51.win->this: +33.5% = 1.335x speedup = +4.1 sigmas
+                 myoutdir->this:  -1.0% = 0.99x speedup = -1.3 sigmas
 
 Rate of doing a foo bar from MyNestedTestcase
  Mean from this run = 1,030 /s with stdDev=10 (1.0% of mean)
-  2022-02-05_14.08.51.win->this: -17.6% = -0.6 sigmas
+  2022-02-05_14.08.51.win->this: -17.6% = 0.824x speedup = -0.6 sigmas
                  myoutdir->this: Compare from value is missing
 

--- a/test/correctness/PySys_internal_181/Reference/perf-summary.out
+++ b/test/correctness/PySys_internal_181/Reference/perf-summary.out
@@ -10,12 +10,12 @@ Comparison results:
   where format is (fromRun->toRun): (%improvement) = (change above 2 sigmas/stdDevs is 95% probability it's significant)
 
 Rate of doing a badda-badda-bing from MyNestedTestcase
- Mean from this run = 2,003 /s, stdDev=1 (0.0% of mean)
+ Mean from this run = 2,003 /s with stdDev=1 (0.0% of mean)
   2022-02-05_14.08.51.win->this: +33.5% = +4.1 sigmas
                  myoutdir->this:  -1.0% = -1.3 sigmas
 
 Rate of doing a foo bar from MyNestedTestcase
- Mean from this run = 1,030 /s, stdDev=10 (1.0% of mean)
+ Mean from this run = 1,030 /s with stdDev=10 (1.0% of mean)
   2022-02-05_14.08.51.win->this: -17.6% = -0.6 sigmas
                  myoutdir->this: Compare from value is missing
 

--- a/test/correctness/PySys_internal_181/Reference/perf-summary.out
+++ b/test/correctness/PySys_internal_181/Reference/perf-summary.out
@@ -1,13 +1,13 @@
 Performance comparison summary between the following runs (the differing "run details" are shown):
 - 2022-02-05_14.08.51.win (3 result keys, 2 samples/result):
      outDirName=historicOutDir, <stripped>
-- myoutdir (1 result keys, 3 samples/result):
+- myoutdir (15 result keys, 1 samples/result):
      outDirName=historicOutDir, <stripped>
 - this (2 result keys, 3 samples/result):
      outDirName=myoutdir, <stripped>
 
 Comparison results:
-  where fromRun->toRun format is: (%improvement) = (speedup ratio) = (sigmas/stdDevs where change above +/- 2.0 gives 95% probability it's significant)
+  where fromRun->toRun format is: (%improvement) = (speedup ratio) = (sigmas/stdDevs where change above +/- 2.0 gives 95% probability it's significant; only significant results are colored)
 
 Rate of doing a badda-badda-bing from MyNestedTestcase
  Mean from this run = 2,003 /s with stdDev=1 (0.0% of mean)

--- a/test/correctness/PySys_internal_181/Reference/perf-summary.out
+++ b/test/correctness/PySys_internal_181/Reference/perf-summary.out
@@ -1,9 +1,9 @@
 Performance comparison summary between the following runs (the differing "run details" are shown):
-- 2022-02-05_14.08.51.win (4 results, 1 samples/result):
+- 2022-02-05_14.08.51.win (3 result keys, 2 samples/result):
      outDirName=historicOutDir, hostname=orighost, startTime=2022-02-05 14:08:51 .. 2022-02-07 16:00:00
-- myoutdir (3 results, 1 samples/result):
+- myoutdir (1 result keys, 3 samples/result):
      outDirName=historicOutDir, hostname=myjsonhost, startTime=2022-02-05 18:38:03
-- this (2 results, 3 samples/result):
+- this (2 result keys, 3 samples/result):
      outDirName=myoutdir, <stripped>
 
 Comparison results:
@@ -12,10 +12,10 @@ Comparison results:
 Rate of doing a badda-badda-bing from MyNestedTestcase
  Mean from this run = 2,003 /s, stdDev=1 (0.0% of mean)
   2022-02-05_14.08.51.win->this: +33.5% = +4.1 sigmas
-                 myoutdir->this:  -1.8% = -36.3 sigmas
+                 myoutdir->this:  -1.0% = -1.3 sigmas
 
 Rate of doing a foo bar from MyNestedTestcase
  Mean from this run = 1,030 /s, stdDev=10 (1.0% of mean)
-  2022-02-05_14.08.51.win->this: -31.3% = -32.3 sigmas
+  2022-02-05_14.08.51.win->this: -17.6% = -0.6 sigmas
                  myoutdir->this: Compare from value is missing
 

--- a/test/correctness/PySys_internal_181/pysystest.py
+++ b/test/correctness/PySys_internal_181/pysystest.py
@@ -1,0 +1,34 @@
+__pysys_title__   = r""" PerformanceReporter - Compare with baseline """ 
+#                        ================================================================================
+
+__pysys_purpose__ = r""" 
+	
+	""" 
+	
+__pysys_authors__ = "bsp"
+__pysys_created__ = "2022-02-04"
+
+import pysys
+from pysys.constants import *
+
+import pysys.utils.logutils
+
+import os, sys, math, shutil, glob
+
+class PySysTest(pysys.basetest.BaseTest):
+
+	def execute(self):
+		self.pysys.pysys('pysys-run', ['run', '-o', self.output+'/myoutdir', '--cycle=3'], workingDir=self.input, 
+			environs={'PYSYS_PERFORMANCE_BASELINES':'__pysys_performance/**/*.csv , __pysys_perform*/*/*.json '})
+		
+	def validate(self):
+		#path = self.grep('pysys-run.out', 'Creating performance summary log file at: (.+)')
+		self.logFileContents('pysys-run.out', maxLines=0, stripWhitespace=False)
+
+		self.assertDiff(self.copy('pysys-run.out', 'perf-summary.out', mappers=[
+			lambda line: pysys.utils.logutils.stripANSIEscapeCodes(line),
+			pysys.mappers.IncludeLinesBetween('Performance comparison', stopBefore=' (CRIT|INFO) '),
+			# strip out the bit that contains timestamps and hostnames from the current run
+			pysys.mappers.RegexReplace('(  outDirName=myoutdir, ).*', r'\1<stripped>'),
+		]))
+		

--- a/test/correctness/PySys_internal_181/pysystest.py
+++ b/test/correctness/PySys_internal_181/pysystest.py
@@ -44,4 +44,6 @@ class PySysTest(pysys.basetest.BaseTest):
 
 		self.assertDiff(self.copy('perf-compare.out', 'perf-compare-no-colors.out', mappers=[
 			lambda line: pysys.utils.logutils.stripANSIEscapeCodes(line),
+			lambda line: line.replace('\\', '/') if ' from ' in line else line, # windows path separator used in "from ..." filename
+			
 		]))

--- a/test/correctness/PySys_internal_181/pysystest.py
+++ b/test/correctness/PySys_internal_181/pysystest.py
@@ -21,7 +21,7 @@ class PySysTest(pysys.basetest.BaseTest):
 		self.pysys.pysys('pysys-run', ['run', '-o', self.output+'/myoutdir', '--cycle=3'], workingDir=self.input, 
 			environs={'PYSYS_PERFORMANCE_BASELINES':'__pysys_performance/**/*.csv , __pysys_perform*/*/*.json '})
 
-		self.startPython([os.path.dirname(pysys.__file__)+'/utils/perfreporter.py', 
+		self.startPython([os.path.dirname(pysys.__file__)+'/perf/perfreportstool.py', 
 			'compare', 
 			# all of 3 of these have some outdir so will generate a label based on something else
 			'__pysys_performance/**/*.csv', 

--- a/test/correctness/PySys_internal_181/pysystest.py
+++ b/test/correctness/PySys_internal_181/pysystest.py
@@ -37,8 +37,8 @@ class PySysTest(pysys.basetest.BaseTest):
 		self.assertDiff(self.copy('pysys-run.out', 'perf-summary.out', mappers=[
 			lambda line: pysys.utils.logutils.stripANSIEscapeCodes(line),
 			pysys.mappers.IncludeLinesBetween('Performance comparison', stopBefore=' (CRIT|INFO) '),
-			# strip out the bit that contains timestamps and hostnames from the current run
-			pysys.mappers.RegexReplace('(  outDirName=myoutdir, ).*', r'\1<stripped>'),
+			# strip out the bit that contains timestamps and hostnames from the current run; all kinds of details like OS and cpu count could also differ
+			pysys.mappers.RegexReplace('(  outDirName=[^,]*, ).*', r'\1<stripped>'),
 			#pysys.mappers.RegexReplace(r'( from ).*(perf_.*)', r'\1<stripped>\2'),
 		]))
 

--- a/test/correctness/PySys_internal_181/pysystest.py
+++ b/test/correctness/PySys_internal_181/pysystest.py
@@ -30,9 +30,9 @@ class PySysTest(pysys.basetest.BaseTest):
 			], workingDir=self.input, stdouterr='perf-compare')
 		
 	def validate(self):
-		self.logFileContents('pysys-run.out', maxLines=0, stripWhitespace=False, tail=True)
+		self.logFileContents('pysys-run.out', maxLines=0, stripWhitespace=False, tail=True, color=False)
 
-		self.logFileContents('perf-compare.out', maxLines=0, stripWhitespace=False, tail=True)
+		self.logFileContents('perf-compare.out', maxLines=0, stripWhitespace=False, tail=True, color=False)
 		
 		self.assertDiff(self.copy('pysys-run.out', 'perf-summary.out', mappers=[
 			lambda line: pysys.utils.logutils.stripANSIEscapeCodes(line),


### PR DESCRIPTION
This PR adds a load of features to make it easier to use PySys for performance testing, mostly focused around the perfreporter API, but also including an automatic comparison of performance results and some detailed UserGuide documentation

Also:
- reworked to support multiple perfreporters not just one, and moved it out of .utils since it deserves a more prominent place
- updated cookook sample to show how to configure the JSON reporter
- try to rename summaryfile -> summaryFile in a backwards compatible way

Non-perf changes while I was at it:
- also add runner.cycles as runner.cycle sounds a bit too much like the "current cycle" whereas of course it's really the total number of cycles; 
- probably solved GH-54 assertThat IndexError (but would like to come back to it to add testing)
- imrpoved logFileContents coloring ad stripWhitespace
- add suppress_prefix option to logger tags to allow the timestamp/loglevel to be omitted where it would distract from the content
