### PR TITLE
Python 3.10 support

### DIFF
--- a/.github/workflows/pysys-test-samples.yml
+++ b/.github/workflows/pysys-test-samples.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: 3.10
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/pysys-test-samples.yml
+++ b/.github/workflows/pysys-test-samples.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/pysys-test.yml
+++ b/.github/workflows/pysys-test.yml
@@ -60,11 +60,11 @@ jobs:
           
           - test-run-id: lnx-py3.10
             os: ubuntu-latest
-            python-version: 3.10
+            python-version: "3.10"
 
           - test-run-id: win-py3.10
             os: windows-latest
-            python-version: 3.10
+            python-version: "3.10"
 
     runs-on: ${{matrix.os}}
     

--- a/.github/workflows/pysys-test.yml
+++ b/.github/workflows/pysys-test.yml
@@ -92,7 +92,7 @@ jobs:
         shell: bash
         run: |
           python --version
-          python -m pip install --upgrade setuptools==59.6.0 wheel
+          python -m pip install --upgrade setuptools wheel
           
           # Set this env var ready for later steps
           echo PYSYS_VERSION=`cat VERSION` >> $GITHUB_ENV

--- a/.github/workflows/pysys-test.yml
+++ b/.github/workflows/pysys-test.yml
@@ -31,40 +31,40 @@ jobs:
       matrix:
         # A selection range of OS, Python and Java versions
         include:
-          - test-run-id: lnx-py3.8-doc-deploy
+          - test-run-id: lnx-py3.10-doc-deploy
             os: ubuntu-latest
-            python-version: 3.8
+            python-version: "3.10"
             doc-and-deploy: true
           
           - test-run-id: mac-py3.7
             os: macos-latest
-            python-version: 3.7
+            python-version: "3.7"
 
           - test-run-id: win-py3.6
             os: windows-latest
-            python-version: 3.6
+            python-version: "3.6"
+
+          - test-run-id: win-py3.10
+            os: windows-latest
+            python-version: "3.10"
 
           # --- Additional testing combinations
 
           #- test-run-id: mac-py3.7
           #  os: macos-latest
-          #  python-version: 3.7
+          #  python-version: "3.7"
 
           #- test-run-id: lnx-py3.6
           #  os: ubuntu-latest
           #  python-version: 3.6
 
-          - test-run-id: lnx-py3.9
-            os: ubuntu-latest
-            python-version: 3.9
+          #- test-run-id: lnx-py3.9
+          #  os: ubuntu-latest
+          #  python-version: "3.9"
           
-          - test-run-id: lnx-py3.10
-            os: ubuntu-latest
-            python-version: "3.10"
-
-          - test-run-id: win-py3.10
-            os: windows-latest
-            python-version: "3.10"
+          #- test-run-id: lnx-py3.9
+          #  os: ubuntu-latest
+          #  python-version: "3.9"
 
     runs-on: ${{matrix.os}}
     

--- a/.github/workflows/pysys-test.yml
+++ b/.github/workflows/pysys-test.yml
@@ -92,7 +92,7 @@ jobs:
         shell: bash
         run: |
           python --version
-          python -m pip install --upgrade setuptools wheel
+          python -m pip install --upgrade setuptools==59.6.0 wheel
           
           # Set this env var ready for later steps
           echo PYSYS_VERSION=`cat VERSION` >> $GITHUB_ENV

--- a/.github/workflows/pysys-test.yml
+++ b/.github/workflows/pysys-test.yml
@@ -54,17 +54,17 @@ jobs:
           #  os: ubuntu-latest
           #  python-version: 3.6
 
-          #- test-run-id: lnx-py3.7
-          #  os: ubuntu-latest
-          #  python-version: 3.7
-          
           - test-run-id: lnx-py3.9
             os: ubuntu-latest
             python-version: 3.9
+          
+          - test-run-id: lnx-py3.10
+            os: ubuntu-latest
+            python-version: 3.10
 
-          - test-run-id: win-py3.9
+          - test-run-id: win-py3.10
             os: windows-latest
-            python-version: 3.9
+            python-version: 3.10
 
     runs-on: ${{matrix.os}}
     
@@ -227,8 +227,7 @@ jobs:
 
       - name: Upload HTML to gh-pages
         if: success() && matrix.doc-and-deploy && (github.event_name == 'release' || github.ref == 'refs/heads/doc-updates')
-        # v4.1.1
-        uses: JamesIves/github-pages-deploy-action@164583b9e44b4fc5910e78feb607ea7c98d3c7b9
+        uses: JamesIves/github-pages-deploy-action@164583b9e44b4fc5910e78feb607ea7c98d3c7b9 # v4.1.1
         with:
           branch: gh-pages
           folder: docs/build_output/html/
@@ -236,8 +235,7 @@ jobs:
       - name: Upload to GitHub Release
         if: success() && matrix.doc-and-deploy && github.event_name == 'release'
         id: upload-release-asset 
-        # v2.2.1
-        uses: svenstaro/upload-release-action@483c1e56f95e88835747b1c7c60581215016cbf2
+        uses: svenstaro/upload-release-action@483c1e56f95e88835747b1c7c60581215016cbf2 # v2.2.1
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           tag: ${{ github.ref }}

--- a/.github/workflows/pysys-test.yml
+++ b/.github/workflows/pysys-test.yml
@@ -147,6 +147,11 @@ jobs:
         id: pysys
         run: |
           export PYTHONWARNINGS=error
+          if [[ ${{ matrix.test-run-id }} = win-py3.10 ]]; then
+            # see also same logic in pysys-extensions/pysysinternalhelpers.py
+            echo TEMPORARILY disabling PYTHONWARNINGS on Windows until PyWin32 v304 is released
+            export PYTHONWARNINGS=ignore
+          fi
           
           # This is necessary to avoid earlier bytecode writing from stopping PYTHONWARNINGS=error set in individual tests 
           # from working

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -61,6 +61,10 @@ New features related to reporting of performance testing:
 - If no ``resultDetails`` are specified explicitly when reporting a result in a test that has modes, then the name and 
   parameters from the test's mode will be recorded as the ``resultDetails``. 
 
+Misc new features:
+
+- Added support for Python 3.10. 
+
 Fixes:
 
 - Fix bug in which a directory named ``!Input_dir_if_present_else_testDir!`` could be created by ``pysys make``. 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -63,7 +63,10 @@ New features related to reporting of performance testing:
 
 Misc new features:
 
-- Added support for Python 3.10. 
+- Added support for Python 3.10. Note that on Windows the following deprecation warning may be seen until PyWin32 
+  releases version 304::
+  
+    DeprecationWarning: getargs: The 'u' format is deprecated. Use 'U' instead.
 
 Fixes:
 

--- a/pysys/perf/reporters.py
+++ b/pysys/perf/reporters.py
@@ -316,7 +316,8 @@ class PrintSummaryPerformanceReporter(BasePerformanceReporter):
 			baselineBaseDir=self.project.testRootDir,
 			paths=os.getenv(self.BASELINES_ENV_VAR,'').split(','), 
 			)
-		log.info('Successfully loaded performance comparison data from %d files: %s', len(self.baselines), ', '.join(b.name for b in self.baselines))
+		if self.baselines:
+			log.info('Successfully loaded performance comparison data from %d files: %s', len(self.baselines), ', '.join(b.name for b in self.baselines))
 
 	def reportResult(self, testobj, value, resultKey, unit, toleranceStdDevs=None, resultDetails=None):
 		with self._lock:

--- a/pysys/process/monitorimpl.py
+++ b/pysys/process/monitorimpl.py
@@ -59,7 +59,7 @@ class WindowsProcessMonitor(BaseProcessMonitor):
 
 	def _getData(self, sample):
 		while True: # loop until we have both a "new" and a "last" value for CPU time
-			if self._stopping.isSet(): raise Exception('Requested to stop')
+			if self._stopping.is_set(): raise Exception('Requested to stop')
 
 			newvalues = {}
 			newvalues['time_ns'] = self._timer_ns()

--- a/pysys/utils/threadpool.py
+++ b/pysys/utils/threadpool.py
@@ -76,7 +76,7 @@ class WorkerThread(threading.Thread):
 		
 		"""
 		threading.Thread.__init__(self, **kwds)
-		log.debug("[%s] Creating thread for test execution" % self.getName())
+		log.debug("[%s] Creating thread for test execution" % self.name)
 		self.daemon = True
 		self._requests_queue = requests_queue
 		self._results_queue = results_queue
@@ -99,10 +99,10 @@ class WorkerThread(threading.Thread):
 					break
 				try:
 					result = request.callable(*request.args, **request.kwds)
-					self._results_queue.put((request, self.getName(), result))
+					self._results_queue.put((request, self.name, result))
 				except:
 					request.exception = True
-					self._results_queue.put((request, self.getName(), sys.exc_info()))
+					self._results_queue.put((request, self.name, sys.exc_info()))
 			time.sleep(0.1)
 					
 	def dismiss(self):

--- a/pysys/utils/threadpool.py
+++ b/pysys/utils/threadpool.py
@@ -87,14 +87,14 @@ class WorkerThread(threading.Thread):
 	def run(self):
 		"""Start running the worker thread."""
 		while True:
-			if self._dismissed.isSet():
+			if self._dismissed.is_set():
 				break
 			try:
 				request = self._requests_queue.get(True, self._poll_timeout)
 			except Queue.Empty:
 				continue
 			else:
-				if self._dismissed.isSet():
+				if self._dismissed.is_set():
 					self._requests_queue.put(request)
 					break
 				try:

--- a/samples/common-files/.github/workflows/pysys-test.yml
+++ b/samples/common-files/.github/workflows/pysys-test.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: 3.10
       - name: Install Python dependencies
         id: deps
         run: |

--- a/samples/common-files/.github/workflows/pysys-test.yml
+++ b/samples/common-files/.github/workflows/pysys-test.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - name: Install Python dependencies
         id: deps
         run: |

--- a/samples/getting-started/bin/my_server.py
+++ b/samples/getting-started/bin/my_server.py
@@ -22,9 +22,16 @@ os.chdir(os.path.dirname(__file__))
 try:
 
 	parser = argparse.ArgumentParser(description='MyServer - a trivial HTTP server used to illustrate how to test a server with PySys.')
-	parser.add_argument('--port', dest='port', type=int, help='The port to listen on')
-	parser.add_argument('--loglevel', dest='loglevel', help='The log level e.g. INFO/DEBUG', default='INFO')
-	parser.add_argument('--configfile', dest='configfile', help='The JSON configuration file for this server')
+	
+	orig_format_help = parser.format_help
+	parser.format_help = lambda: orig_format_help().replace('optional arguments:', 'options:') # Produce same usage on pre-Python 3.10 versions
+	
+	group = parser#parser.add_argument_group('optional arguments:')
+	#group.add_argument('--help', '-h', dest='port', type=int, help='The port to listen on')
+	group.add_argument('--port', dest='port', type=int, help='The port to listen on')
+	group.add_argument('--loglevel', dest='loglevel', help='The log level e.g. INFO/DEBUG', default='INFO')
+	group.add_argument('--configfile', dest='configfile', help='The JSON configuration file for this server')
+	
 	args = parser.parse_args()
 
 	if args.configfile:

--- a/samples/getting-started/test/correctness/MyServer_004/Reference/Usage.my_server.out
+++ b/samples/getting-started/test/correctness/MyServer_004/Reference/Usage.my_server.out
@@ -4,7 +4,7 @@ usage: my_server.py [-h] [--port PORT] [--loglevel LOGLEVEL]
 MyServer - a trivial HTTP server used to illustrate how to test a server with
 PySys.
 
-optional arguments:
+options:
   -h, --help            show this help message and exit
   --port PORT           The port to listen on
   --loglevel LOGLEVEL   The log level e.g. INFO/DEBUG

--- a/test/correctness/PySys_internal_152/run.py
+++ b/test/correctness/PySys_internal_152/run.py
@@ -11,7 +11,7 @@ class PySysTest(BaseTest):
 
 		sampledir = self.project.testRootDir+'/../samples'
 		
-		pythonVersionForCI = "3.9"
+		pythonVersionForCI = "3.10"
 		pythonVersionForMin = "3.6"
 		
 		pysysVersion = pysys.__version__
@@ -44,7 +44,7 @@ class PySysTest(BaseTest):
 				
 				if f == 'pysys-test.yml': # GitHub Actions workflow
 					self.assertThatGrep(p, ' pip install pysys==(.*)', 'value == pysysVersion', pysysVersion=pysysVersion)
-					self.assertThatGrep(p, ' python-version: (.*)', 'value == pythonVersionForCI', pythonVersionForCI=pythonVersionForCI)
+					self.assertThatGrep(p, ' python-version: "?([^"]+)"?', 'value == pythonVersionForCI', pythonVersionForCI=pythonVersionForCI)
 
 				if f == 'run.py':
 					self.assertGrep(p, 'import pysys') # new-style test not an old one we copied from somewhere

--- a/test/correctness/PySys_internal_167/run.py
+++ b/test/correctness/PySys_internal_167/run.py
@@ -34,5 +34,5 @@ class PySysTest(BaseTest):
 		self.assertThatGrep('nonlist.err', '.+', 'expected in value', 
 			expected=": Expecting a list of modes, got a str: 'abcdef'")
 
-		self.assertThatGrep('syntaxerror.err', 'ERROR.+', 'expected in value', 
-			expected='SyntaxError - invalid syntax (<string>, line 3)')
+		self.assertThatGrep('syntaxerror.err', 'ERROR.+', 'expected in value and "line 3" in value', 
+			expected='SyntaxError - ')

--- a/test/pysys-extensions/pysysinternalhelpers.py
+++ b/test/pysys-extensions/pysysinternalhelpers.py
@@ -36,7 +36,9 @@ def runPySys(processowner, stdouterr, args, ignoreExitStatus=False, abortOnError
 	environs.setdefault("PYSYS_USERNAME", "pysystestuser")
 
 	# Error on warnings, to keep everything clean
-	environs.setdefault("PYTHONWARNINGS", "error")
+	environs.setdefault("PYTHONWARNINGS", 
+		# temporarily ignore 3.10 deprecation warnings until PyWin32 releases v304
+		"ignore" if IS_WINDOWS and sys.version_info[0:2]==(3,10) else "error")
 	environs.setdefault("PYTHONDONTWRITEBYTECODE", "true")
 
 	if defaultproject:


### PR DESCRIPTION
Support Python 3.10. Required fixing some new Python deprecation warnings, and fixing a bug in the requires-python project element. 

Had to add a workaround for https://github.com/mhammond/pywin32/pull/1815 until PyWin32 v304 is released