### PR TITLE
Run tests against Python 3.11

### DIFF
--- a/.github/workflows/pysys-test-samples.yml
+++ b/.github/workflows/pysys-test-samples.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/pysys-test.yml
+++ b/.github/workflows/pysys-test.yml
@@ -48,7 +48,7 @@ jobs:
 
           - test-run-id: win-py3.11
             os: windows-latest
-            python-version: "3.10"
+            python-version: "3.11"
 
           # --- Additional testing combinations
 

--- a/.github/workflows/pysys-test.yml
+++ b/.github/workflows/pysys-test.yml
@@ -42,9 +42,9 @@ jobs:
             os: macos-latest
             python-version: "3.7"
 
-          - test-run-id: win-py3.6
+          - test-run-id: win-py3.7
             os: windows-latest
-            python-version: "3.6"
+            python-version: "3.7"
 
           - test-run-id: win-py3.11
             os: windows-latest

--- a/.github/workflows/pysys-test.yml
+++ b/.github/workflows/pysys-test.yml
@@ -76,10 +76,9 @@ jobs:
       # Install Python and dependencies
       - name: Configure Python dependency requirements
         run: |
-          echo setuptools      > setup-python-package-requirements.txt
+          echo setuptools       > setup-python-package-requirements.txt
           echo wheel           >> setup-python-package-requirements.txt
-          # Pinning to 6.2 due to 6.3 hanging on SIGTERM under Linux and Python 3.10 (GH-1310)
-          echo coverage==6.2.0 >> setup-python-package-requirements.txt
+          echo coverage        >> setup-python-package-requirements.txt
       - uses: actions/setup-python@v4
         with:
           python-version: ${{matrix.python-version}}

--- a/.github/workflows/pysys-test.yml
+++ b/.github/workflows/pysys-test.yml
@@ -33,9 +33,9 @@ jobs:
       matrix:
         # A selection range of OS, Python and Java versions
         include:
-          - test-run-id: lnx-py3.10-doc-deploy
+          - test-run-id: lnx-py3.11-doc-deploy
             os: ubuntu-latest
-            python-version: "3.10"
+            python-version: "3.11"
             doc-and-deploy: true
           
           - test-run-id: mac-py3.7
@@ -46,7 +46,7 @@ jobs:
             os: windows-latest
             python-version: "3.6"
 
-          - test-run-id: win-py3.10
+          - test-run-id: win-py3.11
             os: windows-latest
             python-version: "3.10"
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,8 @@ Version 2.2 is under development.
 
 New features:
 
+- Added support for Python 3.11, and removed support for Python 3.6 (which is now end of life). 
+
 - Changed imports in the default new testcase templates to allow Python IDEs to correctly locate the PySys BaseTest class. 
   This allows for code assist/navigation/completion which would otherwise not work. To apply this change to existing tests, 
   change ``import pysys`` to ``import pysys.basetest, pysys.mappers``, and make sure references to `pysys.basetest.BaseTest` 

--- a/README.rst
+++ b/README.rst
@@ -77,7 +77,7 @@ Project Links
 Installation
 ============
 
-PySys can be installed into any Python version from 3.6 to 3.10. 
+PySys can be installed into any Python version from 3.7 to 3.11. 
 
 The best way to install PySys is using the standard ``pip`` installer which 
 downloads and install the binary package for the current PySys 

--- a/pysys/basetest.py
+++ b/pysys/basetest.py
@@ -579,7 +579,7 @@ class BaseTest(ProcessUser):
 		:param \**kwargs: All additional keyword arguments are treated as values which will be made available 
 			when evaluating the condition string. Any keyword ending in the special suffix ``__eval`` will be treated 
 			as a Python expression string (rather than a string literal) and will be be evaluated in a namespace 
-			containing the local variables of the calling code and (on Python 3.6+) any preceding named parameters.  
+			containing the local variables of the calling code and any preceding named parameters.  
 
 		:param \*positional_arguments: (deprecated) Unnamed positional arguments will be 
 			substituted into the condition string using the old ``%`` format string mechanism, before it is evaluated. 
@@ -1038,7 +1038,7 @@ class BaseTest(ProcessUser):
 		:param \**kwargs: All additional keyword arguments are treated as values which will be made available 
 			when evaluating the condition string. Any keyword ending in the special suffix ``__eval`` will be treated 
 			as a Python expression string (rather than a string literal) and will be be evaluated in a namespace 
-			containing the local variables of the calling code and (on Python 3.6+) any preceding named parameters.  
+			containing the local variables of the calling code and any preceding named parameters.  
 		
 		:return: True if the assertion succeeds, False if a failure outcome was appended (and abortOnError=False). 
 

--- a/samples/common-files/.github/workflows/pysys-test.yml
+++ b/samples/common-files/.github/workflows/pysys-test.yml
@@ -41,7 +41,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install pysys==2.2
 
-          pip install coverage==6.2.0
+          pip install coverage
 
       - name: Test with PySys
         working-directory: test

--- a/samples/common-files/.github/workflows/pysys-test.yml
+++ b/samples/common-files/.github/workflows/pysys-test.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Install Python dependencies
         id: deps
         run: |

--- a/samples/cookbook/README.md
+++ b/samples/cookbook/README.md
@@ -16,7 +16,7 @@ license they may use.
 
 # Running the tests
 
-To use this project all you need is Python 3.6+, and the latest version of PySys. 
+To use this project all you need is Python 3.7+, and the latest version of PySys. 
 
 To run all tests - except the manual (non-auto ones) - with recording of the results (to show the functionality of all 
 the configured writers) and code coverage:

--- a/samples/cookbook/test/pysysproject.xml
+++ b/samples/cookbook/test/pysysproject.xml
@@ -11,7 +11,7 @@
 	<requires-pysys>2.2</requires-pysys>
 
 	<!-- Specify a minimum required python version to run these tests. -->
-	<requires-python>3.6</requires-python>
+	<requires-python>3.7</requires-python>
 
 	<!-- 
 		Project properties

--- a/samples/getting-started/README.md
+++ b/samples/getting-started/README.md
@@ -15,7 +15,7 @@ license they may use.
 
 # Running the tests
 
-To use this project all you need is Python 3.6+, and the latest version of PySys. You can run all the tests like this:
+To use this project all you need is Python 3.7+, and the latest version of PySys. You can run all the tests like this:
 
 	cd test
 	pysys.py run

--- a/samples/getting-started/test/pysysproject.xml
+++ b/samples/getting-started/test/pysysproject.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <pysysproject>
 	<requires-pysys>2.2</requires-pysys>
-	<requires-python>3.6</requires-python>
+	<requires-python>3.7</requires-python>
 	
 	<!-- Pre-defined properties include: ${testRootDir}, ${outDirName}, ${os}, ${osfamily}, ${startDate}, ${startTime}, ${hostname}. -->
 	

--- a/setup.py
+++ b/setup.py
@@ -47,11 +47,11 @@ CLASSIFIERS = [
 	"Intended Audience :: Developers",
 	"Programming Language :: Python",
 	"Programming Language :: Python :: 3",
-	"Programming Language :: Python :: 3.6", 
 	"Programming Language :: Python :: 3.7", 
 	"Programming Language :: Python :: 3.8", 
 	"Programming Language :: Python :: 3.9", 
 	"Programming Language :: Python :: 3.10", 
+	"Programming Language :: Python :: 3.11", 
 	# see also python_requires
 	"Programming Language :: Python :: Implementation :: CPython",
 	"Environment :: Console",

--- a/test/correctness/PySys_internal_152/run.py
+++ b/test/correctness/PySys_internal_152/run.py
@@ -11,8 +11,8 @@ class PySysTest(BaseTest):
 
 		sampledir = self.project.testRootDir+'/../samples'
 		
-		pythonVersionForCI = "3.10"
-		pythonVersionForMin = "3.6"
+		pythonVersionForCI = "3.11"
+		pythonVersionForMin = "3.7"
 		
 		pysysVersion = pysys.__version__
 		if 'dev' in pysysVersion: pysysVersion = pysysVersion[:pysysVersion.find('.dev')]

--- a/test/pysysproject.xml
+++ b/test/pysysproject.xml
@@ -6,7 +6,7 @@
 
 
 	<!-- Unlike the samples, we do need to run these with all PySys versions we support -->
-	<requires-python>3.6</requires-python>
+	<requires-python>3.7</requires-python>
 
 	<!-- 
 		The following standard project properties are always defined and can be accessed through ${prop} syntax:


### PR DESCRIPTION
Add support for 3.11, remove support for EoL'd 3.6
Also remove pinning of "coverage" library in order to obtain 3.11 support