### PR TITLE
Add support for Python 3.13

### DIFF
--- a/.github/workflows/pysys-test-samples.yml
+++ b/.github/workflows/pysys-test-samples.yml
@@ -33,10 +33,10 @@ jobs:
     
     steps:
       # Install the desired version of Python and PySys
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.13t"
       - name: Install Python dependencies
         run: |
           python -m pip install --upgrade pip
@@ -74,7 +74,7 @@ jobs:
       # The follow lines are a copy from the sample pysys workflow
 
       - name: Upload performance CSV artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         # Only do this if some performance results were generated
         if: always() && steps.pysys.outputs.artifact_CSVPerformanceReport
 
@@ -83,7 +83,7 @@ jobs:
           path: ${{ steps.pysys.outputs.artifact_CSVPerformanceReport }}
 
       - name: Upload archive artifacts for any test failures
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always() && steps.pysys.outputs.artifact_TestOutputArchiveDir
 
         with:

--- a/.github/workflows/pysys-test.yml
+++ b/.github/workflows/pysys-test.yml
@@ -33,45 +33,46 @@ jobs:
       matrix:
         # A selection range of OS, Python and Java versions
         include:
-          - test-run-id: lnx-py3.12-doc-deploy
+          # Run with the free-threaded (GIl disable-able) build of the latest version
+          - test-run-id: lnx-py3.13t-doc-deploy
             os: ubuntu-latest
-            python-version: "3.12"
+            python-version: "3.13t"
             doc-and-deploy: true
           
-          - test-run-id: mac-py3.8
+          - test-run-id: mac-py3.9
             os: macos-latest
-            python-version: "3.8"
+            python-version: "3.9"
 
-          - test-run-id: win-py3.8
+          - test-run-id: win-py3.9
             os: windows-latest
-            python-version: "3.8"
+            python-version: "3.9"
 
-          - test-run-id: win-py3.12
+          - test-run-id: win-py3.13t
             os: windows-latest
-            python-version: "3.12"
+            python-version: "3.13t"
 
           # --- Additional testing combinations
 
-          #- test-run-id: mac-py3.8
+          #- test-run-id: mac-py3.9
           #  os: macos-latest
-          #  python-version: "3.8"
-
-          #- test-run-id: lnx-py3.8
-          #  os: ubuntu-latest
-          #  python-version: "3.8"
+          #  python-version: "3.9"
 
           #- test-run-id: lnx-py3.9
           #  os: ubuntu-latest
           #  python-version: "3.9"
+
+          #- test-run-id: lnx-py3.10
+          #  os: ubuntu-latest
+          #  python-version: "3.10"
           
-          #- test-run-id: lnx-py3.9
+          #- test-run-id: lnx-py3.10
           #  os: ubuntu-latest
-          #  python-version: "3.9"
+          #  python-version: "3.10"
 
     runs-on: ${{matrix.os}}
     
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       
       # Install Python and dependencies
       - name: Configure Python dependency requirements
@@ -79,7 +80,7 @@ jobs:
           echo setuptools       > setup-python-package-requirements.txt
           echo wheel           >> setup-python-package-requirements.txt
           echo coverage        >> setup-python-package-requirements.txt
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: ${{matrix.python-version}}
           cache: pip
@@ -134,6 +135,8 @@ jobs:
         id: pysys
         run: |
           export PYTHONWARNINGS=error
+          # For tests running in 3.13+, disable the GIL to check that this works
+          export PYTHON_GIL=0
           
           # This is necessary to avoid earlier bytecode writing from stopping PYTHONWARNINGS=error set in individual tests 
           # from working
@@ -153,7 +156,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           
       - name: Upload archive artifacts for any test failures
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: always() && steps.pysys.outputs.artifact_TestOutputArchiveDir
 
         with:
@@ -209,7 +212,7 @@ jobs:
            cp CHANGELOG.rst dist/
 
       - name: Upload Python package .whl
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: success() && matrix.doc-and-deploy
         with:
           name: installation_package
@@ -223,7 +226,7 @@ jobs:
           folder: docs/build_output/html/
 
       - name: Upload to GitHub Release
-        uses: svenstaro/upload-release-action@483c1e56f95e88835747b1c7c60581215016cbf2 # v2.2.1
+        uses: svenstaro/upload-release-action@04733e0 # v2.9.0
         if: success() && matrix.doc-and-deploy && github.event_name == 'release'
         id: upload-release-asset 
         with:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,7 @@ Version 2.3 is under development.
 
 New features:
 
-- XXX
+- Add support for Python 3.13, including the new free-threaded build where the GIL can be disabled. Remove support for the end-of-life 3.8 Python release. 
 
 Fixes in 2.3:
 

--- a/README.rst
+++ b/README.rst
@@ -77,7 +77,7 @@ Project Links
 Installation
 ============
 
-PySys can be installed into any Python version from 3.8 to 3.12. 
+PySys can be installed into any Python version from 3.9 to 3.13. 
 
 The best way to install PySys is using the standard ``pip`` installer which 
 downloads and install the binary package for the current PySys 

--- a/samples/common-files/.github/workflows/pysys-test.yml
+++ b/samples/common-files/.github/workflows/pysys-test.yml
@@ -34,7 +34,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.12"
+          python-version: "3.13t"
       - name: Install Python dependencies
         id: deps
         run: |

--- a/samples/cookbook/README.md
+++ b/samples/cookbook/README.md
@@ -16,7 +16,7 @@ license they may use.
 
 # Running the tests
 
-To use this project all you need is Python 3.8+, and the latest version of PySys. 
+To use this project all you need is Python 3.9+, and the latest version of PySys. 
 
 To run all tests - except the manual (non-auto ones) - with recording of the results (to show the functionality of all 
 the configured writers) and code coverage:

--- a/samples/cookbook/test/pysysproject.xml
+++ b/samples/cookbook/test/pysysproject.xml
@@ -11,7 +11,7 @@
 	<requires-pysys>2.3</requires-pysys>
 
 	<!-- Specify a minimum required python version to run these tests. -->
-	<requires-python>3.8</requires-python>
+	<requires-python>3.9</requires-python>
 
 	<!-- 
 		Project properties

--- a/samples/getting-started/test/pysysproject.xml
+++ b/samples/getting-started/test/pysysproject.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <pysysproject>
 	<requires-pysys>2.3</requires-pysys>
-	<requires-python>3.8</requires-python>
+	<requires-python>3.9</requires-python>
 	
 	<!-- Pre-defined properties include: ${testRootDir}, ${outDirName}, ${os}, ${osfamily}, ${startDate}, ${startTime}, ${hostname}. -->
 	

--- a/setup.py
+++ b/setup.py
@@ -47,11 +47,11 @@ CLASSIFIERS = [
 	"Intended Audience :: Developers",
 	"Programming Language :: Python",
 	"Programming Language :: Python :: 3",
-	"Programming Language :: Python :: 3.8", 
 	"Programming Language :: Python :: 3.9", 
 	"Programming Language :: Python :: 3.10", 
 	"Programming Language :: Python :: 3.11", 
 	"Programming Language :: Python :: 3.12", 
+	"Programming Language :: Python :: 3.13", 
 	# see also python_requires
 	"Programming Language :: Python :: Implementation :: CPython",
 	"Environment :: Console",

--- a/test/correctness/PySys_internal_152/run.py
+++ b/test/correctness/PySys_internal_152/run.py
@@ -11,8 +11,8 @@ class PySysTest(BaseTest):
 
 		sampledir = self.project.testRootDir+'/../samples'
 		
-		pythonVersionForCI = "3.12"
-		pythonVersionForMin = "3.8"
+		pythonVersionForCI = "3.13t"
+		pythonVersionForMin = "3.9"
 		
 		pysysVersion = pysys.__version__
 		if 'dev' in pysysVersion: pysysVersion = pysysVersion[:pysysVersion.find('.dev')]

--- a/test/pysysproject.xml
+++ b/test/pysysproject.xml
@@ -6,7 +6,7 @@
 
 
 	<!-- Unlike the samples, we do need to run these with all PySys versions we support -->
-	<requires-python>3.8</requires-python>
+	<requires-python>3.9</requires-python>
 
 	<!-- 
 		The following standard project properties are always defined and can be accessed through ${prop} syntax:


### PR DESCRIPTION
Including the free-threaded (no-GIL) "t" variant

remove support for the old 3.8;
bump the version of several GH actions (some of the old versions no longer work)